### PR TITLE
Document specialArgs requirement and runtime dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ Use `yo` as voice assistant in 4 steps:
   imports = [ yo.nixosModules.yo ];
 ```
 
+> **Note:** the module also requires `self` and `inputs` as module arguments. Pass them to your `nixosSystem` via `specialArgs`:
+
+```nix
+  nixosSystem {
+    specialArgs = { inherit self inputs; };
+    ...
+  }
+```
+
 <br>
 
 
@@ -138,6 +147,8 @@ services.yo-rs = {
 
 <br>
 
+
+> **Note:** the server and the generated scripts call `piper`, `ffmpeg` and `aplay` from `PATH`. Add them to your packages — in nixpkgs the TTS engine is `piper-tts` (do not use `pkgs.piper`, which is the gaming-mouse GUI): `environment.systemPackages = [ pkgs.piper-tts pkgs.ffmpeg pkgs.alsa-utils ];`
 
 #### **4: Rebuild your system**  
 


### PR DESCRIPTION
Minimal README corrections covering what a fresh user needs to know:

- Step 2: the module requires `self`/`inputs` via `specialArgs` (the README's plain `imports` alone does not evaluate)
- Step 3: the server and generated scripts call `piper`, `ffmpeg` and `aplay` from PATH; in nixpkgs the TTS is `piper-tts` — `pkgs.piper` is the gaming-mouse GUI