### PR TITLE
Expand sentence variants in intent data at build time

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -243,7 +243,7 @@ let
           lists = lib.foldl (acc: d: acc // (d.lists or {})) {} intentList.data;
         in {
           inherit substitutions;
-          inherit sentences;
+          sentences = expandedSentences;
           inherit lists;
         }
       ) generatedIntents


### PR DESCRIPTION
<!-- Título sugerido: Expand sentence variants in intent data at build time -->

## Problem

The generated `intent-data.json` always contains the **raw compact sentences** (e.g. `"(what|whats) the time"`), even though `module.nix` already computes the expanded variants:

```nix
expandedSentences = lib.unique (lib.concatMap expandOptionalWords sentences);
```

...but the JSON writes `inherit sentences;` — the `expandedSentences` value is computed and then discarded. This means:

- The exact-match engine (`yo-do`, Rust) has to re-expand the compact patterns **at runtime, on every query** — duplicated work and a fragile dependency.
- The intent data and the fuzzy index are generated with inconsistent logic (the fuzzy index ships fully expanded variants; the intent data does not).

## Fix

One line — assign the expanded value while keeping the JSON key name `sentences` (the Rust consumer reads that key):

```diff
-          inherit sentences;
+          sentences = expandedSentences;
```

The JSON keeps its `sentences` key, now with the fully expanded variants (`"what the time"`, `"whats the time"`, `"what time is it now"`, ...). The Rust side receives pre-expanded sentences, so its runtime expander becomes a no-op for these.

## Verification

Tested on a real NixOS configuration against this branch's main (which includes the `lib/` restoration):

- Generated `intent-data.json` now contains expanded variants for all voice scripts (verified `time`, `weather`, and a custom script).
- Functional test with the `yo-do` binary against the generated data: exact match resolves correctly for `"pause the movie"` and `"what time is it"`.
- The expansion functions in `lib/default.nix` were verified directly (`(what|whats) the time` → `["what the time", "whats the time"]`).
