### PR TITLE
Use piper-tts instead of piper as buildInputs

### DIFF
--- a/packages/yo-rs.nix
+++ b/packages/yo-rs.nix
@@ -48,7 +48,7 @@ rustPlatform.buildRustPackage {
   buildInputs = [ 
     pkgs.openssl.dev
     pkgs.alsa-lib-with-plugins
-    pkgs.piper
+    pkgs.piper-tts
     pkgs.ffmpeg
   ];
 


### PR DESCRIPTION
## Problem

  There's a "false friend" package mentioned in `buildInputs`.
  
  `pkgs.piper` is included, but  instead of the obvious choice of the TTS synthesizer, it is the driver for a Razr gaming mouse.
  
## Fix

  Simply replaced with the package representing the inteded dependency, which is `piper-tts`.
