### PR TITLE
Restore package binaries and fix recursive script wrappers

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -1173,7 +1173,7 @@ in {
     (mkIf (!cfg.legacy) {      
       yo.scripts.do = {
         description = "do is a Natural Language to Shell script translator that generates dynamic regex patterns at build time for defined yo.script sentences. It runs exact and fuzzy pattern matching at runtime with automatic parameter resolution and seamless shell script execution";
-        binary = "/run/current-system/sw/bin/yo-do";
+        binary = "${config.services.yo-rs.package}/bin/yo-do";
         category = "🗣️ Voice";
         logLevel = "INFO";
         parameters = [
@@ -1185,7 +1185,7 @@ in {
   
       yo.scripts.tests = {
         description = "Extensive automated sentence testing for the yo do"; 
-        binary = "/run/current-system/sw/bin/yo-tests";      
+        binary = "${config.services.yo-rs.package}/bin/yo-tests";      
         category = "🗣️ Voice";
         parameters = [
           { name = "input"; description = "Text to test as a single  sentence test"; optional = true; }
@@ -1197,7 +1197,7 @@ in {
   
       yo.scripts.say = {
         description = "Text to speech with built in language detection and automatic model downloading";
-        binary = "/run/current-system/sw/bin/yo-say";
+        binary = "${config.services.yo-rs.package}/bin/yo-say";
         category = "🗣️ Voice";
         logLevel = "WARNING";
         parameters = [

--- a/packages/yo-rs/Cargo.toml
+++ b/packages/yo-rs/Cargo.toml
@@ -58,8 +58,8 @@ toml = "0.8"
 # ───────────────────────────────────────────────────────────────────────
 # EXECUTABLES
 [[bin]]
-name = "main"
-path = "src/main.rs"
+name = "yo-builder"
+path = "src/yo-builder.rs"
 
 [[bin]]
 name = "yo-client"
@@ -76,5 +76,9 @@ path = "src/yo-tests.rs"
 [[bin]]
 name = "yo-say"
 path = "src/yo-say.rs"
+
+[[bin]]
+name = "yo-toml"
+path = "src/yo-toml.rs"
 
 


### PR DESCRIPTION
## Summary

Two fixes that unblock the NixOS module after the recent refactor (`aa9fa9c`):

1. **Restore the package binaries** (`packages/yo-rs/Cargo.toml`): the server binary `yo-rs` disappeared and `yo-builder`/`yo-toml` were dropped.
2. **Fix the recursive script wrappers** (`module.nix`): the built-in `do`/`tests`/`say` scripts point at themselves, causing infinite recursion.

  Number 2 was a preexisting issue, which I fixed with `nix yo.scripts.do.binary = lib.mkForce "${config.services.yo-rs.package}/bin/yo-do";` and
  forgot about, but was a blocker.

## Fix 1: package binaries (`Cargo.toml`)

`aa9fa9c` changed the executables section:

```diff
 [[bin]]
-name = "yo-builder"
-path = "src/yo-builder.rs"
+name = "main"
+path = "src/main.rs"
 ...
-[[bin]]
-name = "yo-toml"
-path = "src/yo-toml.rs"
```

Because `src/main.rs` is the crate's default binary (package name `yo-rs`), declaring an explicit `[[bin]]` for it under the name `main` **stopped Cargo from generating the `yo-rs` binary** that the module's services use (`getExe cfg.package` → `bin/yo-rs`).


These are logs from my system after rebasing and rebuilding.

```
yo-rs-server.service: Unable to locate executable '/nix/store/.../bin/yo-rs': No such file or directory
yo-rs-server.service: Failed at step EXEC spawning ...: No such file or directory
status=203/EXEC
```

The service entered a restart loop (Restart=always). This fix restores the original executables: `yo-builder` (server entry at `src/main.rs` reverts to the default binary name `yo-rs`) and `yo-toml` (used by the TOML workflow).

## Fix 2: recursive script wrappers (`module.nix`)

The built-in scripts hardcoded their binary to the system path:

```nix
yo.scripts.do    = { binary = "/run/current-system/sw/bin/yo-do"; ... };
yo.scripts.tests = { binary = "/run/current-system/sw/bin/yo-tests"; ... };
yo.scripts.say   = { binary = "/run/current-system/sw/bin/yo-say"; ... };
```

Those symlinks are the **generated wrappers themselves** (unless `yo-rs` happens to be in `systemPackages`), so `yo do "..."` exec'd itself:

```
bash: warning: shell level (1000) too high, resetting to 1   (repeated)
```

This fix points them at the actual package binaries:

```nix
binary = "${config.services.yo-rs.package}/bin/yo-do";
```

(No more dependency on `/run/current-system/sw/bin` or on the package being installed system-wide.)

## Verification

- Package derivation evaluates; `ExecStart` for `yo-rs-server` resolves to the package's `bin/yo-rs`.
- Full NixOS configuration evaluation passes (module + scripts + services).
- The wrapper recursion was reproduced on my system on my first attempts at running the module (`shell level (1000) too high`) and the same interpolation pattern (`${config.services.yo-rs.package}/bin/yo-*`) has been running there as a local override without issues since, to the point I even forgot to create an upstream solution.

## Notes

- Related: the `yo-rs` server binary name is also used by `meta.mainProgram` in `packages/yo-rs.nix` — this restores consistency with it.
- No Cargo.lock impact: renaming binary targets does not change the dependency graph.
