### PR TITLE
Add compile-time fuzzy conflict detection and Whisper models

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ Runtime takes input, runs it through exact and fuzzy matching against the pre‑
 
 `yo` is a **full-stack voice assistant** that's:  
 - **Very Fast** - Pre-compiled indexing, smartt priority ordering & Rust high performance makes it super fast.  
-- **Lightweight** - CLI can be used using only `pkgs.jq` and `pkgs.coreutils`.  
+- **Lightweight** - Legacy Bash CLI requires only `pkgs.jq` and `pkgs.coreutils`.  
+- **Testable** - Exact/fuzzy matching at compile-time detects conflicts.  
 - **Simple** - Bash or Rust - Everything neatly packaged and runs on a single port.  
 - **Safe** - Rule based, user defines the rules. Strong validation supported.    
 - **Offline** - No internet required after setup.
-- **Easy to deploy** - Using the NixOS flake.  
+- **Deployable** - Using the NixOS flake.  
 
 <br>
 
@@ -94,8 +95,8 @@ Example of a minimal server + client service configuration (view `2. Usage` for 
   services.yo-rs = {  
     server = {
       enable         = true;
-      language       = "sv"; # "en" by default
-      model          = "base";
+      language       = "swedish"; # "english" by default
+      whisper        = "base";
       shellTranslate = true;  
     };  
     client.enable = true;
@@ -145,7 +146,7 @@ yo.legacy = true;
 **`yo` uses ONNX Runtime for text-to-speech inference and wake-word detection.**  
 **GGML-based bin models from the Whisper family is used for speech-to-text.**  
 
-> **Note:** models are automatically downloaded at compile-time. Just remember to set a language in the server configuration.  
+> **Note:** models are automatically fetched by Nix. Just remember to set a language in the server configuration.  
 
 
 <br>
@@ -154,7 +155,7 @@ yo.legacy = true;
 ## **2. Usage**
 
 <details><summary><strong>
-Example configuration
+Service configuration
 </strong></summary>
 
 Full usage example:  
@@ -167,13 +168,13 @@ Full usage example:
     server = {
       enable         = true;
       shellTranslate = true;     # true = executes yo scripts
-      language       = "sv";     # controls the transcription language + TTS model (default = `"en"`)
+      language       = "swedish";     # controls the transcription language + TTS model (default = `"english"`)
       whisper        = "medium"; # (tiny, base, small, medium, large) 
       threshold      = 0.8;      # wake word detection trigger threshold
       beamSize       = 0;        # 0 = greedy (often faster)
       temperature    = 0.2;      # can reduce hallucinations
       threads        = 4;        # CPU threads, increase for speed
-      ttsSpeed       = 1.3M #
+      ttsSpeed       = 1.3;      # text-to-speech length-scale
       
       # additional optional settings:
       # host                  = "0.0.0.0:12345";
@@ -188,7 +189,7 @@ Full usage example:
     # Microphone client (streams audio - RMS based VAD)
     client = {
       enable           = true;            # enables microphone streaming to server
-      uri              = "192.168.1.111"; # servert ip (leave unchanged when server & client on same host) 
+      uri              = "192.168.1.111"; # server ip (leave unchanged when server & client on same host) 
       room             = "livingroom";
       silenceThreshold = 0.03;
       silenceTimeout   = 1.5;
@@ -203,18 +204,7 @@ Full usage example:
       # debug              = true;
       # logFile            = "/path/to/custom/log/path/yo-rs-client.log";
     };
-  };
-  
-  yo = {
-    legacy = false;          # set to true to run using Bash
-    SplitWords = [ "also" ]; # used for chaining commands
-    sorryPhrases = [         # TTS when failing
-      "Det låter som du har en köttebulle i käften. Ät klart middagen och försök sedan igen."
-      "Vad fan säger du för något?"
-      "Prata som en människa snälla"
-    ];
-  };
-     
+  };    
 ```
 
 <br>
@@ -223,7 +213,149 @@ Full usage example:
 
 
 <details><summary><strong>
-Example yo.script.<name>.voice definition
+Yo configuration
+</strong></summary>
+
+Most of the options are baked into the service or scripts, but there are a couple of options:   
+
+```nix
+  yo = {
+    fuzzy = {
+      enable = false;        # disable fuzzy globally
+      threshold = 0.9;       # global runtime threshold
+      conflict = {
+        detection = false;   # detect near-duplicate sentences at build-time
+        threshold = 80;      # build-time Jaccard percentage (0–100)
+      };
+    };  
+    legacy = false;          # set to true to run using Bash
+    splitWords = [ "also" ]; # used for chaining commands
+    sorryPhrases = [         # TTS when failing
+      "Buddy, you are speaking Japanese, I dont understand anything."
+      "I'm sorry, I did not understand that"
+      "Sorry, can you repeat that"
+      "I did not quite catch that"
+      "Excuse me?!"
+    ];
+  };
+```
+
+<br>
+
+</details>
+
+<details><summary><strong>
+Script configuration
+</strong></summary>
+
+
+You can see real yo.scripts in the [./examples](https://github.com/QuackHack-McBlindy/yo/tree/main/examples) directory.  
+
+```nix
+yo.scripts.timer = {
+  description = "What this script does";
+  category = "Home Automation";       # used for grouping in `yo --help`
+  aliases = [ "tim" ];                     # alternative CLI names
+  autoStart = false;                      # start at boot? (requires defaults for required parameters)
+  runEvery = "55";                       # run periodically (systemd timer)
+  runAt = [ "08:00" "20:00" ];            # run at specific times daily
+  logLevel = "INFO";                      # DEBUG, INFO, WARNING, ERROR, CRITICAL
+  helpFooter = "Additional help text";
+  parameters = [  
+    { name = "minutes"; type = "int"; description = "Minutes to set the timer on"; default = 0;  }     
+    { name = "seconds"; type = "int"; description = "Seconds to set the timer on"; default = 0; }     
+    { name = "hours"; type = "int"; description = "Hours to set the timer on"; default = 0; }
+    { name = "list"; type = "bool"; description = "Lists active timers"; default = false;  }
+    { name = "sound"; type = "path"; description = "Soundfile to be played on finished timer"; default = "/path/to/finished.wav"; }
+  ];
+  code = ''
+      SOUNDFILE="$sound"
+      HOURS="$hours"
+      MINUTES="$minutes"
+      SECONDS="$seconds"
+
+      LOGFILE_DIR="/tmp/yo-timers"
+      mkdir -p "$LOGFILE_DIR"
+
+      if [ "$list" = "true" ]; then
+        timers=()
+        counter=1
+
+        if ls "$LOGFILE_DIR"/*.pid >/dev/null 2>&1; then
+          for pidfile in "$LOGFILE_DIR"/*.pid; do
+            pid=$(basename "$pidfile" .pid)
+            if ps -p "$pid" >/dev/null 2>&1; then
+              end_time=$(awk '{print $2}' "$pidfile")
+              remaining=$((end_time - $(date +%s)))
+              if [ $remaining -gt 0 ]; then
+                hours_left=$((remaining / 3600))
+                minutes_left=$(((remaining % 3600) / 60))
+                seconds_left=$((remaining % 60))
+                finish_time=$(date -d @$end_time +'%H:%M:%S')
+                timers+=("{\"id\":$pid,\"counter\":$counter,\"target\":\"$finish_time\",\"hours_left\":$hours_left,\"minutes_left\":$minutes_left,\"seconds_left\":$seconds_left}")
+                counter=$((counter + 1))
+              fi
+            else
+              rm -f "$pidfile"
+            fi
+          done
+        fi
+
+        if [ ''${#timers[@]} -eq 0 ]; then
+          echo '{"timers":[]}'
+        else
+          printf '{"timers":[%s]}\n' "$(IFS=,; echo "''${timers[*]}")"
+        fi
+        exit 0
+      fi
+      
+      TIMER_TOTAL=$((HOURS * 3600 + MINUTES * 60 + SECONDS))
+      DURATION=$TIMER_TOTAL
+      TIMER_MINUTES=$((DURATION / 60))
+   
+      start_time=$(date +%s)
+      end_time=$((start_time + DURATION))
+
+      (
+        while [ $(date +%s) -lt $end_time ]; do
+          now=$(date +%s)
+          remaining=$((end_time - now))
+          echo -ne "Time remaining: ''${remaining}s\r"
+          sleep 1
+        done
+
+        echo -e "\n\e[1;5;31m[TIMER FINISHED]\e[0m"
+        rm -f "$LOGFILE_DIR/$$.pid"
+
+
+        if [ -f "$SOUNDFILE" ]; then
+          for i in {1..10}; do
+            aplay "$SOUNDFILE" >/dev/null 2>&1
+          done
+          sleep 15
+          for i in {1..8}; do
+            aplay "$SOUNDFILE" >/dev/null 2>&1
+          done
+        else
+          echo "Sound file not found: $SOUNDFILE"
+        fi
+      ) > /tmp/yo-timer.log 2>&1 &
+      pid=$!
+      echo "$pid $end_time" > "$LOGFILE_DIR/$pid.pid"
+      disown "$pid"
+  '';
+  # or use a pre-built binary:
+  # binary = /path/to/executable;  
+};
+
+```
+
+<br>
+
+</details>
+
+<details><summary><strong>
+Voice configuration
 </strong></summary>
 
 ```nix
@@ -235,8 +367,11 @@ Example yo.script.<name>.voice definition
 You can see real yo.scripts in the [./examples](https://github.com/QuackHack-McBlindy/yo/tree/main/examples) directory.  
 
 ```nix
-    yo.script.timer.voice = {
-      priority = 1;
+  yo.scripts.timer = {
+    voice = {
+      priority = 1;           # (1-5) 5 is priorities last
+      fuzzy.enabled = true;   # script specific
+      fuzzy.threshold = 0.8;  # script specific 
       sentences = [
         "(skapa|ställ|sätt|starta) [en] (time|timer|timern) [på] {hours} (timme|timmar) {minutes} (minut|minuter) {seconds} (sekund|sekunder)"
         "(skapa|ställ|sätt|starta) [en] (time|timer|timern) [på] {minutes} (minut|minuter) [och] {seconds} (sekund|sekunder)"
@@ -249,7 +384,7 @@ You can see real yo.scripts in the [./examples](https://github.com/QuackHack-McB
       ];        
       lists = {
         list.values = [
-          { "in" = "[länge|kvar]"; out = "true"; }
+          { "in" = "länge|kvar"; out = "true"; }
         ];
         seconds.values = builtins.concatLists (builtins.genList (
                 i: let n = i + 1; in [
@@ -277,25 +412,94 @@ You can see real yo.scripts in the [./examples](https://github.com/QuackHack-McB
 
 <br>
 
+
 </details>
 
 
+<details><summary><strong>
+Compile-time sentence conflict evaluation
+</strong></summary>
+
+All checks are pure Nix assertions – if a conflict is found, `nixos-rebuild` fails and a helpful error message is shown.  
+
+```bash
+          200|     if failedAssertions != [ ] then
+          201|       throw "\nFailed assertions:\n${concatStringsSep "\n" (map (x: "- ${x}") failedAssertions)}"
+             |       ^
+          202|     else
+
+       error:
+       Failed assertions:
+       - Sentence conflicts detected in voice definition:
+
+       🦆 says ⮞ CONFLICT!
+         Pattern "set a reminder for {time} to {task}"
+         In scripts: calendar_event, reminderr
+
+       🦆 says ⮞ fix da conflicts before rebuildin' yo!
+```
+
+<br>
+
+**Fuzzy Conflict Detection**
+
+**Jaccard Similarity** compares two sentences by looking at their sets of words (tokens). It’s calculated as:  
+
+`similarity = (number of shared words) / (total unique words in both sentences)`  
+
+The result is a percentage.  
+
+
+> **Example:**  
+`"play music in the living room"` vs `"play radio in the living room"`  
+Shared words: `play, in, the, living, room` (5)  
+Unique words total: `play, music, in, the, living, room, radio` (7)  
+Similarity = **5 / 7 ≈ 71%**
+
+<br>
+
+```nix
+{
+  yo.fuzzy.conflict.detection = true; # default: false
+  yo.fuzzy.conflict.threshold = 70;   # default: 80
+}
+```
+
+Will enable the fuzzy conflict detection and configure its sensitivity value.  
+It's disabled by default as it *(of course)* increases the duration of user rebuilds, but is quite useful for testing.  
+
+
+```bash
+          200|     if failedAssertions != [ ] then
+          201|       throw "\nFailed assertions:\n${concatStringsSep "\n" (map (x: "- ${x}") failedAssertions)}"
+             |       ^
+          202|     else
+
+       error:
+       Failed assertions:
+       - 🦆 duck say ⮞ fuck ❌ Fuzzy index may contain near-duplicate sentences (token similarity > 70%):
+         'play music in the living room' (play_music) vs 'play radio in the living room' (play_radio) [71%]
+```
+
+<br>
+
+</details>
 
 <details><summary><strong>
-Commandline usage
+Commandline
 </strong></summary>
 
 **Natural Language Command**  
 
 Exact matches are blazing fast. 
-Fyzzy matching has great coverage/accuracy.  
+Fuzzy matching has great coverage/accuracy.  
 
 Adding `\?` at the end of your command will run it with `DEBUG` logging.  
 
 Run `yo --help` to see all your defined yo scripts as a table.    
 
 `yo <script> --help` shows the generated patterns and phrases for the defined voice commands.  
-The ratio could be a good way to messure potential combinational explosion as you can see below.  
+The ratio could be a good way to measure potential combinatorial explosion as you can see below.  
 
 ```bash
 ❄️ DOTFILES  on  main [!] 
@@ -330,13 +534,13 @@ If you would run for example:
 yo say "this is my spoken text"
 ```
 
-From your yo server, you would hear `this is my spoken text` on all your clients speakers.  
+From your yo server, you would hear `this is my spoken text` on all connected client's speakers.  
 
 <br>
 
-**Sentence Testing**  
+**Runtime Sentence Testing**  
 
-You can do quite extensive tests for your voice commands:    
+Runtime sentence testing is also supported.      
 
 ```bash
 yo tests
@@ -359,7 +563,7 @@ yo tests --script <name> --max-variants 200
 
 Learn how to write your own voice commands in the [examples/](https://github.com/QuackHack-McBlindy/yo/tree/main/examples)  
 
-For inspiration, view my [/bin](https://github.com/QuackHack-McBlindy/dotfiles/tree/main/bin) - which has voice scripts that ranges between easy to advanced usage.  
+For inspiration, view my [/bin](https://github.com/QuackHack-McBlindy/dotfiles/tree/main/bin) - which has voice scripts that range from easy to advanced usage.   
 
 Read about the fuzzy matching logic in the [docs/](https://github.com/QuackHack-McBlindy/yo/tree/main/docs/FUZZ.md)  
 

--- a/assertions.nix
+++ b/assertions.nix
@@ -191,114 +191,229 @@
         "No sentence conflicts found.";
   };
 
+  # entity list ambiguity
+  listAmbiguities = lib.flatten (lib.mapAttrsToList (scriptName: intent:
+    lib.flatten (lib.mapAttrsToList (listName: listConfig:
+      let
+        values = listConfig.values or [];
+        grouped = lib.groupBy (v: v.${"in"}) values;
+        ambiguous = lib.filterAttrs (input: entries:
+          lib.length (lib.unique (map (e: e.out) entries)) > 1
+        ) grouped;
+      in
+        lib.mapAttrsToList (input: entries:
+          {
+            script = scriptName;
+            list = listName;
+            input = input;
+            outputs = lib.unique (map (e: e.out) entries);
+          }
+        ) ambiguous
+    ) (intent.lists or {}))
+  ) generatedIntents);
+
+  hasListAmbiguities = listAmbiguities != [];
+
+  listAmbiguityAssertion = {
+    assertion = !hasListAmbiguities;
+    message =
+      if hasListAmbiguities then
+        "Entity list ambiguities detected:\n" +
+        lib.concatStringsSep "\n" (map (amb:
+          "  Script '${amb.script}', list '${amb.list}': input '${amb.input}' maps to multiple outputs: " +
+          lib.concatStringsSep ", " amb.outputs
+        ) listAmbiguities)
+      else
+        "No entity list ambiguities.";
+  };
+
+
+  # fuzzy duplicate detection
+  tokenize = s:
+    let
+      chars = lib.stringToCharacters (lib.toLower s);
+      allowed = c: (c >= "a" && c <= "z") || (c >= "0" && c <= "9") || c == " ";
+      cleanedChars = lib.filter allowed chars;
+      cleaned = lib.concatStrings cleanedChars;
+      words = lib.splitString " " cleaned;
+    in
+      lib.unique (lib.filter (w: w != "") words);
+
+  jaccardPercent = a: b:
+    let
+      inter = lib.length (lib.intersectLists a b);
+      union = lib.length (lib.unique (a ++ b));
+    in
+      if union == 0 then 100 else (inter * 100) / union;
+
+  
+  fuzzyDuplicates = let
+    n = builtins.length allExpandedSentences;
+    indices = lib.range 0 (n - 1);
+    pairs = lib.concatMap (i:
+      lib.concatMap (j:
+        if i < j then
+          let
+            itemI = builtins.elemAt allExpandedSentences i;
+            itemJ = builtins.elemAt allExpandedSentences j;
+            scriptI = itemI.scriptName;
+            scriptJ = itemJ.scriptName;
+            sentI = itemI.sentence;
+            sentJ = itemJ.sentence;
+            toksI = tokenize sentI;
+            toksJ = tokenize sentJ;
+            simPercent = jaccardPercent toksI toksJ;
+          in
+            if scriptI != scriptJ && simPercent > cfg.fuzzy.conflict.threshold &&
+               !(sentI == sentJ) &&
+               !(itemI.hasWildcardAtEnd && lib.hasPrefix (sentI + " ") sentJ) &&
+               !(itemJ.hasWildcardAtEnd && lib.hasPrefix (sentJ + " ") sentI)
+            then
+              [{
+                script1 = scriptI;
+                sentence1 = sentI;
+                script2 = scriptJ;
+                sentence2 = sentJ;
+                similarity = simPercent;
+              }]
+            else
+              []
+        else
+          []
+      ) indices
+    ) indices;
+  in pairs;
+
+
+  hasfuzzyDuplicates = fuzzyDuplicates != [];
+
+  fuzzyDuplicateAssertion = {
+    assertion = !hasfuzzyDuplicates;
+    message =
+      if hasfuzzyDuplicates then
+        "🦆 duck say ⮞ fuck ❌ Fuzzy index may contain near-duplicate sentences (token similarity > ${toString cfg.fuzzy.conflict.threshold}%):\n" +
+        lib.concatStringsSep "\n" (map (conf:
+          "  '${conf.sentence1}' (${conf.script1}) vs '${conf.sentence2}' (${conf.script2}) [${toString conf.similarity}%]"
+        ) fuzzyDuplicates)
+      else
+        "No fuzzy duplicates detected.";
+  };
+
 in {
-  config.assertions = let
-    # Errors for runAt (scheduled times)
-    runAtErrors = lib.mapAttrsToList (name: script:
-      if script.runAt != null then
-        let
-          missingParams = lib.filter (p: !p.optional && p.default == null) script.parameters;
-        in
-          if missingParams != [] then
-            "🦆 duck say ⮞ fuck ❌ Cannot schedule '${name}' at ${lib.concatStringsSep ", " script.runAt} - missing defaults for: " +
-            lib.concatMapStringsSep ", " (p: p.name) missingParams
-          else null
-      else null
-    ) scripts;
-    actualRunAtErrors = lib.filter (e: e != null) runAtErrors;
 
-    # build alias > script names map
-    aliasMap = lib.foldl' (acc: script:
-      lib.foldl' (acc': alias:
-        acc' // { ${alias} = (acc'.${alias} or []) ++ [script.name]; }
-      ) acc script.aliases
-    ) {} (lib.attrValues scripts);
+  config = {
+    assertions = let
+      # Errors for runAt (scheduled times)
+      runAtErrors = lib.mapAttrsToList (name: script:
+        if script.runAt != null then
+          let
+            missingParams = lib.filter (p: !p.optional && p.default == null) script.parameters;
+          in
+            if missingParams != [] then
+              "🦆 duck say ⮞ fuck ❌ Cannot schedule '${name}' at ${lib.concatStringsSep ", " script.runAt} - missing defaults for: " +
+              lib.concatMapStringsSep ", " (p: p.name) missingParams
+            else null
+        else null
+      ) scripts;
+      actualRunAtErrors = lib.filter (e: e != null) runAtErrors;
 
-    # conflicts: alias equals a script name
-    scriptNameConflicts = lib.filterAttrs (alias: _: lib.elem alias scriptNames) aliasMap;
+      # build alias > script names map
+      aliasMap = lib.foldl' (acc: script:
+        lib.foldl' (acc': alias:
+          acc' // { ${alias} = (acc'.${alias} or []) ++ [script.name]; }
+        ) acc script.aliases
+      ) {} (lib.attrValues scripts);
 
-    # duplicate aliases (same alias used by multiple scripts)
-    duplicateAliases = lib.filterAttrs (_: scrs: lib.length scrs > 1) aliasMap;
+      # conflicts: alias equals a script name
+      scriptNameConflicts = lib.filterAttrs (alias: _: lib.elem alias scriptNames) aliasMap;
 
-    # auto‑start scripts missing defaults for required parameters
-    autoStartErrors = lib.mapAttrsToList (name: script:
-      if script.autoStart then
-        let
-          missingParams = lib.filter (p: !p.optional && p.default == null) script.parameters;
-        in
-          if missingParams != [] then
-            "🦆 duck say ⮞ fuck ❌ Cannot auto-start '${name}' - missing defaults for: " +
-            lib.concatMapStringsSep ", " (p: p.name) missingParams
-          else null
-      else null
-    ) scripts;
-    actualAutoStartErrors = lib.filter (e: e != null) autoStartErrors;
+      # duplicate aliases (same alias used by multiple scripts)
+      duplicateAliases = lib.filterAttrs (_: scrs: lib.length scrs > 1) aliasMap;
 
-    # Parameters that have a `values` list but are not of type `string`
-    valueTypeErrors = lib.concatMap (script:
-      lib.concatMap (param:
-        if param.values != null && param.type != "string" then
-          [ "🦆 duck say ⮞ fuck ❌ Parameter '${param.name}' in script '${script.name}' has 'value' defined but type is '${param.type}' (only 'string' type allowed)" ]
-        else []
-      ) script.parameters
-    ) (lib.attrValues scripts);
+      # auto‑start scripts missing defaults for required parameters
+      autoStartErrors = lib.mapAttrsToList (name: script:
+        if script.autoStart then
+          let
+            missingParams = lib.filter (p: !p.optional && p.default == null) script.parameters;
+          in
+            if missingParams != [] then
+              "🦆 duck say ⮞ fuck ❌ Cannot auto-start '${name}' - missing defaults for: " +
+              lib.concatMapStringsSep ", " (p: p.name) missingParams
+            else null
+        else null
+      ) scripts;
+      actualAutoStartErrors = lib.filter (e: e != null) autoStartErrors;
 
-  in [
-    # Alias conflicts with script names
-    {
-      assertion = scriptNameConflicts == {};
-      message = "🦆 duck say ⮞ fuck ❌ Alias/script name conflicts:\n" +
-        lib.concatStringsSep "\n" (lib.mapAttrsToList formatConflict scriptNameConflicts);
-    }
-
-    # Duplicate aliases
-    {
-      assertion = duplicateAliases == {};
-      message = "🦆 duck say ⮞ fuck ❌ Duplicate aliases:\n" +
-        lib.concatStringsSep "\n" (lib.mapAttrsToList formatDuplicate duplicateAliases);
-    }
-
-    # Code/binary exclusivity (first check)
-    {
-      assertion = failingScripts == [];
-      message = "The following scripts do not have exactly one of `code` or `binary` defined (non‑empty): " +
-        lib.concatStringsSep ", " (lib.map (s: s.name) failingScripts);
-    }
-
-    # Auto‑start scripts with missing defaults
-    {
-      assertion = actualAutoStartErrors == [];
-      message = "Auto-start errors:\n" + lib.concatStringsSep "\n" actualAutoStartErrors;
-    }
-
-    # scheduled scripts (runAt) with missing defaults
-    {
-      assertion = actualRunAtErrors == [];
-      message = "runAt scheduling errors:\n" + lib.concatStringsSep "\n" actualRunAtErrors;
-    }
-
-    # cannot have both runEvery and runAt
-    {
-      assertion = lib.all (script: !(script.runEvery != null && script.runAt != null)) (lib.attrValues scripts);
-      message = "🦆 duck say ⮞ fuck ❌ Script cannot have both runEvery and runAt set";
-    }
-
-    # `values` only allowed for string parameters
-    {
-      assertion = valueTypeErrors == [];
-      message = "Value type errors:\n" + lib.concatStringsSep "\n" valueTypeErrors;
-    }
-
-    # Code/binary exclusivity
-    {
-      assertion = lib.all (script:
-        (script.code != null && script.code != "" && script.binary == null) ||
-        (script.binary != null && (script.code == null || script.code == ""))
+      # Parameters that have a `values` list but are not of type `string`
+      valueTypeErrors = lib.concatMap (script:
+        lib.concatMap (param:
+          if param.values != null && param.type != "string" then
+            [ "🦆 duck say ⮞ fuck ❌ Parameter '${param.name}' in script '${script.name}' has 'value' defined but type is '${param.type}' (only 'string' type allowed)" ]
+          else []
+        ) script.parameters
       ) (lib.attrValues scripts);
-      message = "Each script must have exactly one of `code` or `binary` defined (non‑empty).";
-    }
 
-    # Voice sentence conflict assertion
-    voiceConflictAssertion
+    in [
+      # Alias conflicts with script names
+      {
+        assertion = scriptNameConflicts == {};
+        message = "🦆 duck say ⮞ fuck ❌ Alias/script name conflicts:\n" +
+          lib.concatStringsSep "\n" (lib.mapAttrsToList formatConflict scriptNameConflicts);
+      }
 
-  ];}
+      # Duplicate aliases
+      {
+        assertion = duplicateAliases == {};
+        message = "🦆 duck say ⮞ fuck ❌ Duplicate aliases:\n" +
+          lib.concatStringsSep "\n" (lib.mapAttrsToList formatDuplicate duplicateAliases);
+      }
+
+      # Code/binary exclusivity (first check)
+      {
+        assertion = failingScripts == [];
+        message = "The following scripts do not have exactly one of `code` or `binary` defined (non‑empty): " +
+          lib.concatStringsSep ", " (lib.map (s: s.name) failingScripts);
+      }
+
+      # Auto‑start scripts with missing defaults
+      {
+        assertion = actualAutoStartErrors == [];
+        message = "Auto-start errors:\n" + lib.concatStringsSep "\n" actualAutoStartErrors;
+      }
+
+      # scheduled scripts (runAt) with missing defaults
+      {
+        assertion = actualRunAtErrors == [];
+        message = "runAt scheduling errors:\n" + lib.concatStringsSep "\n" actualRunAtErrors;
+      }
+
+      # cannot have both runEvery and runAt
+      {
+        assertion = lib.all (script: !(script.runEvery != null && script.runAt != null)) (lib.attrValues scripts);
+        message = "🦆 duck say ⮞ fuck ❌ Script cannot have both runEvery and runAt set";
+      }
+
+      # `values` only allowed for string parameters
+      {
+        assertion = valueTypeErrors == [];
+        message = "Value type errors:\n" + lib.concatStringsSep "\n" valueTypeErrors;
+      }
+
+      # Code/binary exclusivity
+      {
+        assertion = lib.all (script:
+          (script.code != null && script.code != "" && script.binary == null) ||
+          (script.binary != null && (script.code == null || script.code == ""))
+        ) (lib.attrValues scripts);
+        message = "Each script must have exactly one of `code` or `binary` defined (non‑empty).";
+      }
+
+      # Voice sentence conflict assertion (always enabled)
+      voiceConflictAssertion
+    ] ++ lib.optionals cfg.fuzzy.conflict.detection [
+      # Fuzzy checks (opt‑in)
+      listAmbiguityAssertion
+      fuzzyDuplicateAssertion
+    ];
+
+  };}

--- a/module.nix
+++ b/module.nix
@@ -302,7 +302,7 @@ let
     (script.voice.fuzzy.enable or true)  # 🦆 Must explicitly allow fuzzy
   ) config.yo.scripts;
 
-  splitWordsFile = pkgs.writeText "split-words.json" (builtins.toJSON config.yo.SplitWords);
+  splitWordsFile = pkgs.writeText "split-words.json" (builtins.toJSON config.yo.splitWords);
   sorryPhrasesFile = pkgs.writeText "sorry-phrases.json" (builtins.toJSON config.yo.sorryPhrases);
   fuzzyIndexFile = pkgs.writeText "fuzzy-index.json" (builtins.toJSON fuzzyIndex);
   fuzzyIndexFlatFile = pkgs.writeText "fuzzy-rust-index.json" (builtins.toJSON fuzzyFlatIndex);  
@@ -1178,7 +1178,7 @@ in {
         logLevel = "INFO";
         parameters = [
           { name = "input"; description = "Text to translate"; optional = true; } 
-          { name = "fuzzy"; type = "int"; description = "Minimum procentage for considering fuzzy matching sucessful. (1-100)"; default = 25; }
+          { name = "fuzzy"; type = "int"; description = "Minimum procentage for considering fuzzy matching sucessful. (1-100)"; default = builtins.floor (config.yo.fuzzy.threshold * 100); }
           { name = "room"; type = "string"; description = "Optional client area (used for context)"; optional = true; }
         ];
       };
@@ -1190,7 +1190,7 @@ in {
         parameters = [
           { name = "input"; description = "Text to test as a single  sentence test"; optional = true; }
           { name = "stats"; type = "bool"; description = "Flag to display voice commands information like generated regex patterns, generated phrases and ratio"; optional = true; }    
-          { name = "fuzzy"; type = "int"; description = "Minimum procentage for considering fuzzy matching sucessful. (1-100)"; default = 30; }
+          { name = "fuzzy"; type = "int"; description = "Minimum procentage for considering fuzzy matching sucessful. (1-100)"; default = builtins.floor (config.yo.fuzzy.threshold * 100); }
           { name = "script"; type = "string"; description = "Extensive sentence testing of the specified script"; optional = true; }
           { name = "max-variants"; type = "int"; description = "Maximum number of variants tested peer sentence."; optional = true; default = 50; }
         ];

--- a/options.nix
+++ b/options.nix
@@ -3,7 +3,7 @@
   lib,
   ...
 } : let
-
+  cfg = config.yo;
   utils = import ./lib { inherit lib; };
   inherit (utils) countGeneratedPatterns countUnderstoodPhrases;
 
@@ -79,10 +79,11 @@
         readOnly = true;
       };
       voiceRatio = lib.mkOption {
-        type = lib.types.int;
-        internal = true;
-        readOnly = true;
-      };      
+       type = lib.types.float;
+       internal = true;
+       readOnly = true;
+        default = 0.0;
+      };    
       parameters = lib.mkOption {
         type = lib.types.listOf (lib.types.submodule {
           options = {
@@ -125,8 +126,14 @@
             fuzzy = lib.mkOption {
               type = lib.types.submodule {
                 options = {
-                  enable = lib.mkOption { type = lib.types.bool; default = true; };
-                  threshold = lib.mkOption { type = lib.types.float; default = 0.8; };
+                  enable = lib.mkOption {
+                    type = lib.types.bool;
+                    default = cfg.fuzzy.enable;          # ← direct value
+                  };
+                  threshold = lib.mkOption {
+                    type = lib.types.float;
+                    default = cfg.fuzzy.threshold;       # ← direct value
+                  };
                 };
               };
               default = {};
@@ -189,8 +196,8 @@
       );
       voicePatterns = lib.mkDefault (countGeneratedPatterns config);
       voicePhrases  = lib.mkDefault (countUnderstoodPhrases config);
-      voiceRatio    = if config.yo.generatedPatterns == 0 then 0.0
-                        else (builtins.toFloat config.yo.understandsPhrases) / (builtins.toFloat config.yo.generatedPatterns);
+      voiceRatio = if config.voicePatterns == 0 then 0.0
+                     else (builtins.toFloat config.voicePhrases) / (builtins.toFloat config.voicePatterns);
     };
   });
 
@@ -256,7 +263,7 @@ in {
       ];
       description = "List of phrases for TTS when no match is found";
     };
-    SplitWords = lib.mkOption {
+    splitWords = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ "also" ];
       description = "Words used for command chaining, i.e. multiple executions";
@@ -265,6 +272,29 @@ in {
       type = lib.types.bool;
       default = false;
       description = "Use the legacy version of the shell translator in Bash instead of Rust";
+    };
+
+    fuzzy = lib.mkOption {
+      type = lib.types.submodule {
+        options = {
+          enable = lib.mkOption { type = lib.types.bool; default = true; };
+          threshold = lib.mkOption { type = lib.types.float; default = 0.8; };
+          conflict = lib.mkOption {
+            type = lib.types.submodule {
+              options = {
+                detection = lib.mkEnableOption "deep build-time conflict detection ...";
+                threshold = lib.mkOption {
+                  type = lib.types.int;
+                  default = 80;
+                  description = "Token Jaccard similarity percentage ...";
+                };
+              };
+            };
+            default = {};
+          };
+        };
+      };
+      default = {};
     };
     scripts = lib.mkOption {
       type = lib.types.attrsOf scriptType;

--- a/packages/yo-rs.nix
+++ b/packages/yo-rs.nix
@@ -39,6 +39,26 @@ let
         url = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large.bin";
         sha256 = lib.fakeSha256;
       }
+    else if model == "large-v1" then
+      pkgs.fetchurl {
+        url = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v1.bin";
+        sha256 = "sha256-fZn0GhBSXQIGvdrdhnYBgfqSBDi2szI34xGP9sg7tT0=";
+      }
+    else if model == "large-v2" then
+      pkgs.fetchurl {
+        url = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v2.bin";
+        sha256 = "sha256-mkI/5NQMgndLavNBFbi5NfNBUiRusZ6A43YHHT+ZlIc=";
+      }
+    else if model == "large-v3" then
+      pkgs.fetchurl {
+        url = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3.bin";
+        sha256 = "sha256-ZNGCtEC5jVIDxPm9VBVE2ExgUZbE97hF36EfsjWU0eI=";
+      }
+    else if model == "large-v3-turbo" then
+      pkgs.fetchurl {
+        url = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin";
+        sha256 = "sha256-H8cPd0046xaZk6w5Huo1fvR8iHV+9y7llDh5t+jivGk=";
+      }      
     else
       pkgs.fetchurl {
         url = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin";


### PR DESCRIPTION
**Summary**
Added optional compile-time assertions for entity-list ambiguity and Jaccard-based fuzzy duplicate sentence detection, enabled via yo.fuzzy.conflict.detection.

Introduced global yo.fuzzy settings (enable, threshold, conflict.detection, conflict.threshold) and made script-level fuzzy defaults inherit them.

Renamed SplitWords to splitWords; built-in script fuzzy defaults now derive from config.yo.fuzzy.threshold.

Added Whisper model fetch definitions for large-v1, large-v2, large-v3, and large-v3-turbo.

Updated README with new configuration sections, corrected typos, and changed model/language documentation examples.

**Why**
Build-time conflict checking lets users catch ambiguous or near-duplicate voice patterns before deployment.

A global fuzzy configuration point reduces duplication and makes script defaults consistent.

Additional Whisper models and documentation updates reflect expanded model support and current option names.


**Notes**
SplitWords was renamed to splitWords; existing NixOS configs using the old capitalization will break.

Fuzzy duplicate and entity-list ambiguity assertions are opt-in through yo.fuzzy.conflict.detection; the existing voice sentence conflict assertion remains always enabled.

voiceRatio changed from integer to float, and its calculation now uses config.voicePatterns and config.voicePhrases.

README examples use whisper instead of model and full language names such as "swedish" instead of "sv".