### PR TITLE
Upgrade whisper, add match types, tests, and config enhancements

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -20,3 +20,6 @@ jobs:
 
       - name: Build flake
         run: nix flake check --all-systems
+        
+      #- name: Run Rust tests
+      #  run: nix develop -c cargo test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Unit tests for matching logic, normalization, optional words, and fuzzy behavior.
-- `tempfile` as a dev dependency for testing.
 
 ### Changed
+
+### Fixed
+
+### Removed
+
+## [0.2.4] - 08-28-2026
+
+### Added
+- Unit tests for matching logic, normalization, optional words, and fuzzy behavior.
+- `tempfile` as a dev dependency for testing.
+- `ttsClients` option in `services.nix` to hardcode client IPs for TTS streaming.
+- Transcription benchmark logging to `~/.config/yo/whisper-bench.txt`.
+- `match_type` field in `MatchResult` to distinguish exact and fuzzy matches.
+
+### Changed
+- Upgraded `whisper-rs` from 0.8 to 0.16, with API adaptations (e.g., `WhisperContext::new_with_params`, `full_n_segments`, `get_segment`).
 - Fuzzy matching now evaluates all sentence patterns and validates extracted parameters, returning a fallback result if validation fails.
-- `normalize_input` also removes apostrophes (e.g., "what's" -> "whats").
+- `normalize_input` also removes apostrophes and collapses extra whitespace.
 - Loading split words and sorry phrases now returns empty vectors instead of panicking if files are missing or invalid.
-- Added `match_type` field to `MatchResult` to differentiate exact and fuzzy matches; output message now uses "quack!" for exact and "quack?!" for fuzzy.
+- Output message now uses "quack!" for exact matches and "quack?!" for fuzzy matches.
 - Execution time line now prefixed with "**Execution time**".
 - Version bumped to 0.2.4.
-- Commented out Rust test step in Nix CI workflow (temporary).
+- Nix module changes: disabled `fuzzy` command parameter (temporary), added number formatting for large counts, changed help output structure, and added `/etc/yo/table.md`.
+- `yo-say` now reads `clients.json` from both `$HOME/.config/yo/` and `/etc/yo/`.
+- CI workflow: commented out Rust test step.
 
 ### Fixed
 - Parameter extraction for fuzzy matches with multiple patterns now correctly maps input words to pattern placeholders.
+- Transcription timing now always measured and logged (removed debug-gating).
 
 ### Removed
 - `fuzzy` command parameter temporarily disabled (commented out in module.nix).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Unit tests for matching logic, normalization, optional words, and fuzzy behavior.
+- `tempfile` as a dev dependency for testing.
+
+### Changed
+- Fuzzy matching now evaluates all sentence patterns and validates extracted parameters, returning a fallback result if validation fails.
+- `normalize_input` also removes apostrophes (e.g., "what's" -> "whats").
+- Loading split words and sorry phrases now returns empty vectors instead of panicking if files are missing or invalid.
+- Added `match_type` field to `MatchResult` to differentiate exact and fuzzy matches; output message now uses "quack!" for exact and "quack?!" for fuzzy.
+- Execution time line now prefixed with "**Execution time**".
+- Version bumped to 0.2.4.
+- Commented out Rust test step in Nix CI workflow (temporary).
+
+### Fixed
+- Parameter extraction for fuzzy matches with multiple patterns now correctly maps input words to pattern placeholders.
+
+### Removed
+- `fuzzy` command parameter temporarily disabled (commented out in module.nix).

--- a/README.md
+++ b/README.md
@@ -1,31 +1,23 @@
 
 [![Sponsors](https://img.shields.io/github/sponsors/QuackHack-McBlindy?logo=githubsponsors&label=Sponsor&style=flat&labelColor=ff1493&logoColor=fff&color=rgba(234,74,170,0.5) "")](https://github.com/sponsors/QuackHack-McBlindy) [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-Sponsor?style=flat&logo=buymeacoffee&logoColor=fff&labelColor=ff1493&color=ff1493)](https://buymeacoffee.com/quackhackmcblindy)
 
-# **It's Nix & deterministic, `yo`!**
+# **`yo`, 3 quick:**  
+
+
+1. **Take a script & give it parameters.**  
+2. **Write sentences and entity lists for the script.**   
+3. **Execute the script using text or speech.**  
+
+<br>
 
 `yo` is:
 - **Nix: compile-time command-language compiler & verifier**  
 - **Rust: deterministic run-time interpreter, matcher & dispatcher**  
 - **Lightweight: Legacy CLI requires only `pkgs.bash` + `pkgs.jq` & `pkgs.coreutils`!**   
 
-``` 
-🦆🏠  HOME via 🐍 via 🦀 v1.98.0 took 1m31s 
-03:36:35 ❯ yo do "seetlt ao tiimezrr fobor twoz hourazs ninre minuotes twentyonz<e secondips"
-   ┌─(yo-timer-en)
-   │🦆 qwack!? seetlt ao tiimezrr fobor twoz hourazs ninre minuotes twentyonz<e secondips
-   └─⮞ --hours 2
-   └─⮞ --minutes 9
-   └─⮞ --seconds 21
-   └─⏰ do took 52.417625ms
-{
-  "status": "ok",
-  "timer_id": 1
-}
-```
-
 <br>
 
-**Nix Build Time**
+**Nix Build Time**  
 ▶ declarative command definitions  
 ▶ grammar expansion  
 ▶ parameter/entity expansion  
@@ -42,14 +34,30 @@
 >  Once a match is selected, parameters are extracted and the corresponding `yo` script is dispatched with those arguments.  
 
 
-`yo` is a **full-stack voice assistant** that's:  
+``` 
+🦆🏠  HOME via 🐍 via 🦀 v1.98.0 took 1m31s 
+03:36:35 ❯ yo do "seetlt ao tiimezrr fobor twoz hourazs ninre minuotes twentyonz<e secondips"
+   ┌─(yo-timer-en)
+   │🦆 qwack!? seetlt ao tiimezrr fobor twoz hourazs ninre minuotes twentyonz<e secondips
+   └─⮞ --hours 2
+   └─⮞ --minutes 9
+   └─⮞ --seconds 21
+   └─⏰ do took 52.417625ms
+{
+  "status": "ok",
+  "timer_id": 1
+}
+```
+
+
+`yo` is also a **full-stack voice assistant** that's:  
 - **Very Fast** - Pre-compiled indexes, priority-ordered exact matching, parallel fuzzy evaluation & Rust performance.  
 - **Simple** - Everything neatly packaged and runs on a single port.  
 - **Safe** - Rule based, user defines the rules. Strong validation included.     
-- **Configurable** - Optimize fuzzy threshold per script.   
+- **Configurable** - Optimize fuzzy threshold per script, makes it very flexible.   
 - **Offline** - No internet required after setup.  
 - **Embeddable** - ESP32 based clients in Rust using the [yo-esp](https://github.com/QuackHack-McBlindy/yo-esp) library.  
-- **Ready** - Voice commands are exact/fuzzy tested for conflicts before service starts.  
+- **Ready** - Voice commands are exact/fuzzy tested for conflicts before service even starts.  
 - **Deployable** - 100% reproducible using the NixOS flake.  
 
 
@@ -170,6 +178,8 @@ yo.legacy = true;
 Service configuration
 </strong></summary>
 
+<br>
+
 Full usage example:  
 
 ```nix
@@ -179,14 +189,14 @@ Full usage example:
   
     server = {
       enable         = true;
-      shellTranslate = true;     # true = executes yo scripts
-      language       = "swedish";     # controls the transcription language + TTS model (default = `"english"`)
-      whisper        = "medium"; # (tiny, base, small, medium, large) 
-      threshold      = 0.8;      # wake word detection trigger threshold
-      beamSize       = 0;        # 0 = greedy (often faster)
-      temperature    = 0.2;      # can reduce hallucinations
-      threads        = 4;        # CPU threads, increase for speed
-      ttsSpeed       = 1.3;      # text-to-speech length-scale
+      shellTranslate = true;      # true = executes yo scripts
+      language       = "swedish"; # controls the transcription language + TTS model (default = `"english"`)
+      whisper        = "medium";  # (tiny, base, small, medium, large) 
+      threshold      = 0.8;       # wake word detection trigger threshold
+      beamSize       = 0;         # 0 = greedy (often faster)
+      temperature    = 0.2;       # can reduce hallucinations
+      threads        = 4;         # CPU threads, increase for speed
+      ttsSpeed       = 1.3;       # text-to-speech length-scale
       
       # additional optional settings:
       # host                  = "0.0.0.0:12345";
@@ -203,9 +213,9 @@ Full usage example:
       enable           = true;            # enables microphone streaming to server
       uri              = "192.168.1.111"; # server ip (leave unchanged when server & client on same host) 
       room             = "livingroom";
-      silenceThreshold = 0.03;
-      silenceTimeout   = 1.5;
-      maxDuration      = 5.0; # max recording in seconds before sending
+      silenceThreshold = 0.03;            # when to concider audio silent
+      silenceTimeout   = 1.5;             # wait x seconds after silent before sending
+      maxDuration      = 5.0;             # max recording in seconds before sending
       
       # awakeSound         = "/path/to/custom/awake.wav";
       # doneSound          = "/path/to/custom/done.wav";
@@ -227,6 +237,8 @@ Full usage example:
 <details><summary><strong>
 Yo configuration
 </strong></summary>
+
+<br>
 
 Most of the options are baked into the service or scripts, but there are a couple of options:   
 
@@ -260,6 +272,7 @@ Most of the options are baked into the service or scripts, but there are a coupl
 Script configuration
 </strong></summary>
 
+<br>
 
 You can see real yo.scripts in the [./examples](https://github.com/QuackHack-McBlindy/yo/tree/main/examples) directory.  
 
@@ -370,12 +383,17 @@ yo.scripts.timer = {
 Voice configuration
 </strong></summary>
 
+<br>
+
+This is how you define sentences with words.  
+
 ```nix
 (these|are|alternative|words)  
 [these|are|optional|words]  
 {parameters}
 ```
 
+A good rule of thumb is to place the sentences with the most parameters at the top and work your way down.   
 You can see real yo.scripts in the [./examples](https://github.com/QuackHack-McBlindy/yo/tree/main/examples) directory.  
 
 ```nix
@@ -431,6 +449,8 @@ You can see real yo.scripts in the [./examples](https://github.com/QuackHack-McB
 <details><summary><strong>
 Compile-time sentence conflict evaluation
 </strong></summary>
+
+<br>
 
 All checks are pure Nix assertions – if a conflict is found, `nixos-rebuild` fails and a helpful error message is shown.  
 
@@ -501,49 +521,107 @@ It's disabled by default as it *(of course)* increases the duration of user rebu
 Commandline
 </strong></summary>
 
+<br>
+
 **Natural Language Command**  
 
-Exact matches are blazing fast. 
-Fuzzy matching has great coverage/accuracy.  
+Commands are executed from the terminal:  
+
+```bash
+$ yo do "turn off all lights in the livingroom"
+```
 
 Adding `\?` at the end of your command will run it with `DEBUG` logging.  
 
-Run `yo --help` to see all your defined yo scripts as a table.    
+<br>
 
-`yo <script> --help` shows the generated patterns and phrases for the defined voice commands.  
+Exact matches are blazing fast.  
+Fuzzy matching has great coverage/accuracy.  
+
+The duck will let you know if you just had an **exact match** by saying:  
+`🦆 qwack!`   
+if it was an **fuzzy match**:  
+`🦆 qwack?!`  
+
+
+Run `yo --help` to see all your defined yo scripts as a table. *(Can also be viewed at `/etc/yo/table.md`)*   
+
+`yo <script> --help` shows all of the `yo` scripts information as well as the number of generated patterns and phrases for the defined voice commands.  
 The ratio could be a good way to measure potential combinatorial explosion as you can see below.  
 
 ```bash
 ❄️ DOTFILES  on  main [!] 
 00:41:44 ❯ yo tv -h
-  ...                                                                           
-  ## Voice Commands                                                           
+🦆🏠  HOME via 🐍 via 🦀 v1.98.0 
+00:49:35 ❯ yo tv -h
+                                                                            
+  Android TV Controller. Fuzzy search all media types and creates playlist and
+  serves over webserver for casting.                                          
+  Usage:  yo tv [OPTIONS]                                                     
+                                                                              
+  ## Parameters                                                               
+                                                                              
+   --typ                                                                      
+  Specify the type of command or the media type to search for.                
+  Supported commands are:                                                     
+  on, off, up, down, call, favorites, star.                                   
+  Media Types:                                                                
+  tv, movie, livetv, podcast, music, song, musicvideo, jukebox (random music),
+  othervideo, youtube.                                                        
+  Device Naviagation:                                                         
+  nav_up, nav_down, nav_left, nav_right, nav_select, nav_menu, nav_back       
+                                                                              
+  (optional) (default: tv)                                                    
+  (allowed: on, off, up, down, next, prev, call, favourites, star, tv, movie, 
+  livetv, podcast, music, song, musicvideo, jukebox, othervideo, youtube,     
+  nav_up, nav_down, nav_left, nav_right, nav_select, nav_menu, nav_back,      
+  channel_up, channel_down)                                                   
+                                                                              
+   --search                                                                   
+  Media to search                                                             
+  (optional)                                                                  
+                                                                              
+   --room                                                                     
+  Room name of device to play on                                              
+  (optional)                                                                  
+                                                                              
+   --season                                                                   
+  Specific season to play                                                     
+  (optional)                                                                  
+                                                                              
+   --shuffle                                                                  
+  Shuffle Toggle, true or false                                               
+  (optional) (default: true)                                                  
+                                                                               
+  ## Voice                                                           
                                                                               
   Patterns: 245                                                               
-  Phrases: 1608                                                               
-  Ratio: 6                                                                              
+  Phrases: 1,608                                                              
+  Ratio: 6                                                                       
 ```
 
 ```bash
 ❄️ DOTFILES  on  main [!] 
 00:41:52 ❯ yo timer -h
   ...                                                                                                                                
-  ## Voice Commands                                                           
+  ## Voice                                                           
                                                                               
   Patterns: 921                                                               
-  Phrases: 262010985                                                          
-  Ratio: 284485
+  Phrases: 262,010,985                                                        
+  Ratio: 284,485                                                              
 ```
 
 <br>
 
-> **Note:** for **legacy** that timer script becomes **6.66 MB**, while for Rust version only a kilobytes.    
+> **Note:** for **legacy** that timer script becomes **6.66 MB**, while for Rust version well below 100 kilobytes.    
+
+<br>
 
 > **Hint:** Tte timer script is a perfect example of when priority `5` should be defined.  
 
 <br>
 
-To see a total of generated patterns/phrases and a averge processing time run: `yo do --help`.  
+To see a total of generated patterns/phrases and averge benchmarking statistics: `yo do --help`.  
 
 <br>
 
@@ -556,6 +634,19 @@ yo say "this is my spoken text"
 ```
 
 From your yo server, you would hear `this is my spoken text` on all connected client's speakers.  
+
+<br>
+
+If that does not work as epected users may hardcode a list of client IP's:  
+
+```nix
+  services.yo-rs = {
+    client = {
+      ttsClients = [ "192.168.1.123" "192.168.1.124" ];
+    };
+  };  
+}
+```
 
 <br>
 
@@ -595,7 +686,7 @@ Read more about the feature set in the [docs/](https://github.com/QuackHack-McBl
 ## **Sponsor My Work**
 
 [![Sponsors](https://img.shields.io/github/sponsors/QuackHack-McBlindy?logo=githubsponsors&label=Sponsor&style=flat&labelColor=ff1493&logoColor=fff&color=rgba(234,74,170,0.5) "")](https://github.com/sponsors/QuackHack-McBlindy) [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-Sponsor?style=flat&logo=buymeacoffee&logoColor=fff&labelColor=ff1493&color=ff1493)](https://buymeacoffee.com/quackhackmcblindy)
-> 🦆🧑‍🦯 says ⮞ Hi! I'm QuackHack-McBlindy!  
+> 🦯🦆 says ⮞ Hi! I'm QuackHack-McBlindy!  
 > Like my work?  
 > Buy me a coffee, or become a sponsor.  
 > Thanks for supporting open source/hungry developers ♥️🦆!   

--- a/legacy.nix
+++ b/legacy.nix
@@ -419,6 +419,8 @@ in {
         fi
         exit
       '';
+      voice.fuzzy.enable = false;
+      voice.fuzzy.threshold = 0.0;
     };
     
     
@@ -701,6 +703,8 @@ in {
         dt_info "Test completed with results: $passed_tests/$total_tests ''${percent}%"
         exit 1
       '';
+      voice.fuzzy.enable = false;
+      voice.fuzzy.threshold = 0.0;
     };
  
   };}

--- a/module.nix
+++ b/module.nix
@@ -658,6 +658,21 @@ let
             phrases  = countUnderstoodPhrases script;
             ratio    = if patterns == 0 then 0 else builtins.div phrases patterns;
 
+            formatNumber = n:
+              let
+                s = toString n;
+                go = str: acc:
+                  if str == "" then acc
+                  else
+                    let
+                      start = lib.max 0 (builtins.stringLength str - 3);
+                      chunk = builtins.substring start 3 str;
+                      rest  = builtins.substring 0 start str;
+                    in
+                      go rest (if acc == "" then chunk else chunk + "," + acc);
+              in
+                go s "";
+
             replaceParamsWithValues = sentence: voiceData:
               let
                 processToken = token:
@@ -698,7 +713,7 @@ let
               "- \"${escapeMD sentence}\"\n"
             ) processedSentences;
           in
-            "## Voice Commands\n\nPatterns: ${toString patterns}  \nPhrases: ${toString phrases}  \nRatio: ${toString ratio}  \n\n${sentencesMarkdown}"
+            "## Voice Commands\n\nPatterns: ${formatNumber patterns}  \nPhrases: ${formatNumber phrases}  \nRatio: ${formatNumber ratio}  \n\n"
         else "";
        
         param_usage = lib.concatMapStringsSep " " (param:
@@ -767,11 +782,12 @@ let
                 fi
                 
                 cat <<EOF | ${pkgs.glow}/bin/glow --width "$width" - # Render as markdown 
-# 🚀🦆 yo ${escapeMD script.name}
+# yo ${escapeMD script.name}
 ${script.description}
 **Usage:** \`yo ${escapeMD script.name}''${usage_suffix}\`
 ${lib.optionalString (script.parameters != []) ''
-## Parameters
+
+# ▶ Parameters
 ${lib.concatStringsSep "\n\n" (map (param: ''
 **\`--${param.name}\`**  
 ${param.description}  
@@ -969,6 +985,7 @@ EOF
   totalPhrases = config.yo.understandsPhrases;
   ratio = if totalPatterns == 0 then "N/A"
           else toString (builtins.div totalPhrases totalPatterns);
+          
 in {
   imports = [
     ./options.nix
@@ -992,6 +1009,7 @@ in {
         "yo/intent-data.json".source = intentDataFile;
         "yo/fuzzy-index.json".source = fuzzyIndexFlatFile;
         "yo/fuzzy-entity-dict.json".source = fuzzyEntityDictFile;
+        "yo/table.md".source = terminalScriptsTableFile; 
       };
   
       environment.systemPackages = [
@@ -1004,16 +1022,16 @@ in {
           show_help() {
             width=130
             cat <<EOF | ${pkgs.glow}/bin/glow --width $width -
-          ### ──────⋆⋅☆☆☆⋅⋆────── ##
+          # ──────⋆⋅☆☆☆⋅⋆──────
           **Usage:** \`yo <command> [arguments]\`
-          ### ──────⋆⋅☆☆☆⋅⋆────── ##
-          ### 🦆✨ Available Commands
+          # ──────⋆⋅☆☆☆⋅⋆────── 
+          ## 🦆✨ Available Commands
           Parameters inside brackets are [optional]
           | Command Syntax               | Aliases    | Description |
           |------------------------------|------------|-------------|
           ${terminalScriptsTable}
-          ### ──────⋆⋅☆☆☆⋅⋆────── ##
-          ### 🦆❓ Detailed Help
+          # ──────⋆⋅☆☆☆⋅⋆────── 
+          ## Detailed Help
           For specific command help: \`yo <command> --help\`
           \`yo do --help\` will list all defined voice intents.
           EOF
@@ -1166,29 +1184,45 @@ in {
       
     (mkIf (!cfg.legacy) {      
       yo.scripts.do = {
-        description = "do is a Natural Language to Shell script translator that generates dynamic regex patterns at build time for defined yo.script sentences. It runs exact and fuzzy pattern matching at runtime with automatic parameter resolution and seamless shell script execution";
+        description = "do is a natural language to shell script translator thIt runs exact and fuzzy pattern matching at runtime with automatic parameter resolution and seamless shell script execution";
         binary = "${yo-rs-with-models}/bin/yo-do";
         category = "🗣️ Voice";
         logLevel = "INFO";
         helpFooter = ''
-          printf '%s\n' \
-            '**Total generated patterns:** ${toString totalPatterns}' \
-            '**Total generated phrases:** ${toString totalPhrases}' \
-            '**Ratio (phrases / patterns):** ${ratio}'
+          group_number() {
+            local n="$1"
+            printf '%s' "$n" | rev | sed 's/.\{3\}/&,/g' | rev | sed 's/^,//'
+          }
+          printf '# ▶ Voice\n\n'
+          printf '**Total generated patterns:** %s\n' \
+            "$(group_number ${toString totalPatterns})"
+          printf '**Total generated phrases:** %s\n' \
+            "$(group_number ${toString totalPhrases})"
+          if (( ${toString totalPatterns} > 0 )); then
+            printf '**Ratio (phrases / patterns):** %s\n' \
+              "$(group_number ${toString (totalPhrases / totalPatterns)})"
+          else
+            printf '**Ratio (phrases / patterns):** N/A\n'
+          fi          
           if [ -f "$HOME/.config/yo/exec.txt" ]; then
             first_line=$(head -n 1 "$HOME/.config/yo/exec.txt")
-            printf '%s\n' "$first_line"
+            printf '**Execution time:** %s\n' "$first_line"
           fi
+          if [ -f "$HOME/.config/yo/whisper-bench.txt" ]; then
+            first_line=$(head -n 1 "$HOME/.config/yo/whisper-bench.txt")
+            printf '**Transcription time:** %s\n' "$first_line"
+          fi          
         '';
         parameters = [
           { name = "input"; description = "Text to translate"; optional = true; } 
-          { name = "fuzzy"; type = "int"; description = "Minimum procentage for considering fuzzy matching sucessful. (1-100)"; default = builtins.floor (config.yo.fuzzy.threshold * 100); }
           { name = "room"; type = "string"; description = "Optional client area (used for context)"; optional = true; }
         ];
+        voice.fuzzy.enable = false;
+        voice.fuzzy.threshold = 0.0;
       };
   
       yo.scripts.tests = {
-        description = "Extensive automated sentence testing for the yo do"; 
+        description = "Extensive automated run-time sentence testing for the yo do"; 
         binary = "${yo-rs-with-models}/bin/yo-tests";      
         category = "🗣️ Voice";
         parameters = [
@@ -1198,11 +1232,13 @@ in {
           { name = "script"; type = "string"; description = "Extensive sentence testing of the specified script"; optional = true; }
           { name = "max-variants"; type = "int"; description = "Maximum number of variants tested peer sentence."; optional = true; default = 50; }
         ];
+        voice.fuzzy.enable = false;
+        voice.fuzzy.threshold = 0.0;
       };  
   
   
       yo.scripts.say = {
-        description = "Text to speech with built in language detection and automatic model downloading";
+        description = "Text to speech with baked in model and full duplex audio streaming";
         binary = "${yo-rs-with-models}/bin/yo-say";
         category = "🗣️ Voice";
         logLevel = "WARNING";
@@ -1216,6 +1252,8 @@ in {
            })
           { name = "length-scale"; description = "Speech speed"; optional = true; default = config.services.yo-rs.server.ttsSpeed; }                    
         ];
+        voice.fuzzy.enable = false;
+        voice.fuzzy.threshold = 0.0;
       };
     })
     

--- a/packages/yo-rs/Cargo.lock
+++ b/packages/yo-rs/Cargo.lock
@@ -168,28 +168,6 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bindgen"
-version = "0.64.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
-dependencies = [
- "bitflags 1.3.2",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex 1.3.0",
- "syn 1.0.109",
- "which",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -198,10 +176,12 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "shlex 1.3.0",
  "syn 2.0.119",
 ]
@@ -411,6 +391,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,7 +468,7 @@ version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9b4739a805a62757a83e5654fa3faabec0442666b263bb2287d5a8185bfd953"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
 ]
 
 [[package]]
@@ -542,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -987,6 +976,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,15 +1118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1480,12 +1466,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "lewton"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,18 +1500,12 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2053,12 +2027,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,6 +2123,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2408,12 +2386,6 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
@@ -2434,19 +2406,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.13.1",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2454,7 +2413,7 @@ dependencies = [
  "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -2497,6 +2456,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2559,7 +2524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -2767,7 +2732,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -3293,34 +3258,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "whisper-rs"
-version = "0.8.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c950fb18ad556b053ba615b88fd4d01ed6020be740c3371eb0fc4aec64a0639"
+checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
 dependencies = [
  "whisper-rs-sys",
 ]
 
 [[package]]
 name = "whisper-rs-sys"
-version = "0.6.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "094a5bd86f6f52562bbc74c28f27cd80197e54656cfb7213cf4ba37b5246cc9e"
+checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
 dependencies = [
- "bindgen 0.64.0",
+ "bindgen",
  "cfg-if",
+ "cmake",
+ "fs_extra",
+ "semver",
 ]
 
 [[package]]
@@ -3678,12 +3634,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]
 name = "yo-rs"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/packages/yo-rs/Cargo.toml
+++ b/packages/yo-rs/Cargo.toml
@@ -2,7 +2,7 @@
 # PACKAFGE INFO
 [package]
 name    = "yo-rs"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 # ───────────────────────────────────────────────────────────────────────
 description = """
@@ -21,7 +21,8 @@ clap        = { version = "4.0", features = ["derive"] }
 tokio       = { version = "1", features   = ["full"] }
 serde       = { version = "1.0", features = ["derive"] }
 oww-rs      = { path = "vendor/oww-rs" }
-whisper-rs  = "0.8"
+#whisper-rs  = "0.8"
+whisper-rs  = "0.16"
 serde_json  = "1.0"
 cpal        = "0.16"
 anyhow      = "1.0"
@@ -50,6 +51,8 @@ regex  = "1.0"
 rand   = "0.8"
 rayon = "1.10"
 
+[dev-dependencies]
+tempfile = "3"
 # ───────────────────────────────────────────────────────────────────────
 # EXECUTABLES
 # Server
@@ -73,7 +76,7 @@ name = "yo-say"
 path = "src/yo-say.rs"
 
 
-# Sentences testing
+# Run-time Sentences testing
 [[bin]]
 name = "yo-tests"
 path = "src/yo-tests.rs"

--- a/packages/yo-rs/src/main.rs
+++ b/packages/yo-rs/src/main.rs
@@ -27,7 +27,7 @@ use oww_rs::{
     oww::{OwwModel, OWW_MODEL_CHUNK_SIZE},
 };
 
-use whisper_rs::{WhisperContext, FullParams, SamplingStrategy};
+use whisper_rs::{WhisperContext, WhisperContextParameters, FullParams, SamplingStrategy};
 use serde::{Serialize, Deserialize};
 
 lazy_static::lazy_static! {
@@ -206,6 +206,81 @@ fn sox_noisered(samples: &[f32], sample_rate: u32, amount: f32) -> Result<Vec<f3
     Ok(cleaned)
 }
 
+
+// ───────────────────────────────────────────────────────────────────────
+// BENCHMARK
+fn log_transcription_time(
+    client_id: &str,
+    start: Instant,
+    audio_samples: usize,
+    sample_rate: u32,
+    model: &str,
+    beam_size: i32,
+    threads: i32,
+) {
+    let elapsed = start.elapsed();
+    let audio_secs = audio_samples as f64 / sample_rate as f64;
+    dt_info!(
+        "[{}] Transcription finished: audio={:.2}s, proc={:.3}s (model={}, beam={}, threads={})",
+        client_id,
+        audio_secs,
+        elapsed.as_secs_f64(),
+        model,
+        beam_size,
+        threads
+    );
+}
+
+fn log_transcription_benchmark(time_secs: f64, model: &str) {
+    let home = env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    let dir = PathBuf::from(&home).join(".config/yo");
+    let file_path = dir.join("whisper-bench.txt");
+
+    if let Err(e) = fs::create_dir_all(&dir) {
+        dt_error!("Failed to create config dir for benchmark: {}", e);
+        return;
+    }
+
+    let mut entries: Vec<(f64, String)> = Vec::new();
+    if let Ok(content) = fs::read_to_string(&file_path) {
+        for line in content.lines().skip(1) {
+            let trimmed = line.trim();
+            if let Some(parts) = trimmed.split_once(" s (") {
+                if let Ok(secs) = parts.0.trim().parse::<f64>() {
+                    let model_part = parts.1.trim_end_matches(')').to_string();
+                    entries.push((secs, model_part));
+                }
+            }
+        }
+    }
+    let model_name = std::path::Path::new(model)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(model)
+        .to_string();
+    entries.push((time_secs, model_name));
+    
+    let latest_model = entries
+        .last()
+        .map(|(_, m)| m.clone())
+        .unwrap_or_else(|| model.to_string());
+
+    let (sum, count) = entries
+        .iter()
+        .filter(|(_, m)| *m == latest_model)
+        .fold((0.0_f64, 0_u64), |(acc, cnt), (t, _)| (acc + t, cnt + 1));
+    let average = if count > 0 { sum / count as f64 } else { 0.0 };
+
+    let header = format!("{:.2} s average using model: {} ({} entries)", average, latest_model, count);
+    let mut output = header + "\n";
+    for (secs, model_entry) in &entries {
+        output.push_str(&format!("{:.3} s ({})\n", secs, model_entry));
+    }
+    if let Err(e) = fs::write(&file_path, output) {
+        dt_error!("Failed to write benchmark file: {}", e);
+    }
+}
+
 // ───────────────────────────────────────────────────────────────────────
 fn handle_intercom(
     mut stream: TcpStream,
@@ -353,6 +428,7 @@ fn handle_client(
     translate_to_shell: bool,
     room: String,
     sender_ip: String,     
+    whisper_model_path: String,
 ) -> Result<()> {  
     let mut last_detection: Option<Instant> = None;
 
@@ -465,7 +541,7 @@ fn handle_client(
             };
 
             
-            let perf_start = if debug { Some(Instant::now()) } else { None };
+            let perf_start = Instant::now(); 
 
             // 🦆 says ⮞ Transcribe
             let sampling_strategy = if beam_size > 0 {
@@ -484,30 +560,26 @@ fn handle_client(
             whisper_params.set_print_timestamps(false);
             whisper_params.set_temperature(temperature);
             whisper_params.set_suppress_blank(true);
-            whisper_params.set_suppress_non_speech_tokens(true);
+            whisper_params.set_suppress_nst(true);
             // whisper_params.set_token_timestamps(true);
 
             let mut state = whisper_ctx.create_state().expect("failed to create state");
             if let Err(e) = state.full(whisper_params, &transcription_audio) {
                 dt_error!("[{}] Whisper transcription failed: {}", client_id, e);
             } else {
-                let num_segments = state.full_n_segments()? as usize;
+                let num_segments = state.full_n_segments() as usize;
                 let mut transcription = String::new();
                 for i in 0..num_segments {
-                    let segment = state.full_get_segment_text(i as i32)?;
-                    transcription.push_str(&segment);
+                    if let Some(segment) = state.get_segment(i as i32) {
+                        transcription.push_str(&segment.to_string());
+                    } else { dt_warning!("[{}] Missing segment {}", client_id, i); }
                 }
                 dt_info!("[{}] Transcription: {}", client_id, transcription);
                 write_last_sender_ip(&sender_ip);
                 
-
-                // 🦆 says ⮞ if --debug
-                if debug { // 🦆 says ⮞ print transcription timer
-                    if let Some(start) = perf_start {
-                        let elapsed = start.elapsed();
-                        dt_debug!("[{}] Transcription took {:.3}s", client_id, elapsed.as_secs_f64());
-                    }
-                }
+                log_transcription_time(&client_id, perf_start, transcription_audio.len(), 16000, &whisper_model_path, beam_size, threads);
+                let elapsed_secs = perf_start.elapsed().as_secs_f64();
+                log_transcription_benchmark(elapsed_secs, &whisper_model_path);
 
                 let normalized = normalize_transcription(&transcription);
                 if debug { dt_debug!("[{}] Normalized: {}", client_id, normalized); }
@@ -623,6 +695,7 @@ fn handle_ptt(
     done_sound_data: Vec<u8>,
     fail_sound_data: Vec<u8>,
     sender_ip: String,
+    whisper_model_path: String,
 ) -> Result<()> {
     let mut audio_buffer: Vec<f32> = Vec::new();
 
@@ -709,15 +782,18 @@ fn handle_ptt(
                 params.set_print_timestamps(false);
                 params.set_temperature(temperature);
                 params.set_suppress_blank(true);
-                params.set_suppress_non_speech_tokens(true);
+                params.set_suppress_nst(true);
 
+                let perf_start = Instant::now();
                 let mut state = whisper_ctx.create_state()?;
                 let transcription = match state.full(params, &cleaned_audio) {         
                     Ok(_) => {
-                        let n = state.full_n_segments()?;
+                        let n = state.full_n_segments() as usize;
                         let mut text = String::new();
                         for i in 0..n {
-                            text.push_str(&state.full_get_segment_text(i)?);
+                            if let Some(segment) = state.get_segment(i as i32) {
+                                text.push_str(&segment.to_string());
+                            }
                         }
                         text
                     }
@@ -729,6 +805,10 @@ fn handle_ptt(
                     }
                 };
 
+                log_transcription_time(&client_id, perf_start, cleaned_audio.len(), 16000, &whisper_model_path, beam_size, threads);
+                let elapsed_secs = perf_start.elapsed().as_secs_f64();
+                log_transcription_benchmark(elapsed_secs, &whisper_model_path);
+                
                 let normalized = normalize_transcription(&transcription);
                 dt_info!("[{}] PTT transcription: {}", client_id, normalized);
                 write_last_sender_ip(&sender_ip);
@@ -748,9 +828,7 @@ fn handle_ptt(
                                 if status.success() {
                                     dt_info!("🎉 {} Shell translation successful!", client_id);
                                     command_succeeded = true;
-                                } else {
-                                    dt_error!("[{}] Shell translator failed with exit code: {:?}", client_id, status.code());
-                                }
+                                } else { dt_error!("[{}] Shell translator failed with exit code: {:?}", client_id, status.code()); }
                             }
                             Err(e) => dt_error!("[{}] Failed to execute yo do: {}", client_id, e),
                         }
@@ -797,9 +875,7 @@ fn handle_ptt(
                 // SAVE RECORDING TO DISK FOR DEBUG
                 if let Err(e) = save_audio_to_file(&cleaned_audio, &client_id) {
                     dt_error!("[{}] failed to save audio: {}", client_id, e);
-                }
-
-                
+                }                
             }
             _ => {
                 dt_error!("[{}] unexpected PTT message type 0x{:02x}", client_id, msg_type);
@@ -831,6 +907,7 @@ fn handle_client_esp(
     room: String,
     //audio_out: Option<Arc<Mutex<TcpStream>>>,
     sender_ip: String,
+    whisper_model_path: String,
 ) -> Result<()> {
     enum State {
         Normal,
@@ -997,7 +1074,7 @@ fn handle_client_esp(
 
                     // TRANSCRIBE
                     //let transcription_audio = buffer;
-                    let perf_start = if debug { Some(Instant::now()) } else { None };
+                    let perf_start = Instant::now();
                     dt_info!("[{}] Sending to Whisper: {} samples ({:.2}s)",
                         client_id, transcription_audio.len(),
                         transcription_audio.len() as f64 / SAMPLE_RATE as f64);
@@ -1016,28 +1093,26 @@ fn handle_client_esp(
                     whisper_params.set_print_timestamps(false);
                     whisper_params.set_temperature(temperature);
                     whisper_params.set_suppress_blank(true);
-                    whisper_params.set_suppress_non_speech_tokens(true);
+                    whisper_params.set_suppress_nst(true);
 
                     let mut whisper_state = whisper_ctx.create_state().expect("failed to create state");
                     let mut command_succeeded = false;
                     if let Err(e) = whisper_state.full(whisper_params, &transcription_audio) {
                         dt_error!("[{}] Whisper transcription failed: {}", client_id, e);
                     } else {
-                        let num_segments = whisper_state.full_n_segments()? as usize;
+                        let num_segments = whisper_state.full_n_segments() as usize;
                         let mut transcription = String::new();
                         for i in 0..num_segments {
-                            let segment = whisper_state.full_get_segment_text(i as i32)?;
-                            transcription.push_str(&segment);
+                            if let Some(segment) = whisper_state.get_segment(i as i32) {
+                                transcription.push_str(&segment.to_string());
+                            }
                         }
                         dt_info!("TRANSCRIPTION: {}", transcription);
 
                         write_last_sender_ip(&sender_ip);
-                        if debug {
-                            if let Some(start) = perf_start {
-                                let elapsed = start.elapsed();
-                                dt_debug!("[{}] Transcription took {:.3}s", client_id, elapsed.as_secs_f64());
-                            }
-                        }
+                        log_transcription_time(&client_id, perf_start, transcription_audio.len(), 16000, &whisper_model_path, beam_size, threads);
+                        let elapsed_secs = perf_start.elapsed().as_secs_f64();
+                        log_transcription_benchmark(elapsed_secs, &whisper_model_path);
 
                         // 🦆 says ⮞ optionally cut transcription at first punctuation (enable if hallucination is a big problem)
                         let mut transcription = transcription;
@@ -1513,7 +1588,7 @@ fn main() -> Result<()> {
         translate_to_shell,
     );
 
-    let whisper_ctx = Arc::new(WhisperContext::new(&whisper_model_path)?);
+    let whisper_ctx = Arc::new(WhisperContext::new_with_params(&whisper_model_path, WhisperContextParameters::default())?);
   
     let client_registry = Arc::new(Mutex::new(ClientRegistry::new()));  
   
@@ -1594,6 +1669,7 @@ fn main() -> Result<()> {
                     //let room_for_handler = room_for_thread.clone();
                     let display_for_handler = display_id.clone();
                     let room_for_removal = registry_room;
+                    let whisper_model_path_for_ptt = whisper_model_path.clone();
                     
                     thread::spawn(move || {
                         if let Err(e) = handle_ptt(
@@ -1612,6 +1688,7 @@ fn main() -> Result<()> {
                             done_sound_data,
                             fail_sound_data,
                             sender_ip,
+                            whisper_model_path_for_ptt.clone(),
                         ) {
                             dt_error!("[{}] PTT handler error: {}", display_id, e);
                         }
@@ -1640,7 +1717,8 @@ fn main() -> Result<()> {
                 let exec_command = exec_command.clone();
                 let whisper_ctx = Arc::clone(&whisper_ctx);
                 let language = language.clone();
-                
+                let whisper_model_path_for_thread = whisper_model_path.clone();              
+              
                 let wake_model = if custom_wake_word_provided {
                     match OwwModel::from_path(&wake_word_path, threshold) {
                         Ok(m) => m,
@@ -1658,7 +1736,7 @@ fn main() -> Result<()> {
                         }
                     }
                 };
-                
+                                
                 thread::spawn(move || {
                     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                         if room_clone == "esp" {
@@ -1679,7 +1757,8 @@ fn main() -> Result<()> {
                                 exec_command,
                                 translate_to_shell,
                                 room_clone.clone(),
-                                ip_clone, 
+                                ip_clone,
+                                whisper_model_path_for_thread.clone(),
                             );
                         } else {
                             let _ = handle_client(
@@ -1700,6 +1779,7 @@ fn main() -> Result<()> {
                                 translate_to_shell,
                                 room_clone.clone(),
                                 ip_clone,
+                                whisper_model_path_for_thread.clone(),
                             );
                         }
                     }));

--- a/packages/yo-rs/src/yo-do.rs
+++ b/packages/yo-rs/src/yo-do.rs
@@ -15,7 +15,6 @@ use std::fs;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
 use futures_util::{SinkExt, StreamExt};
 use serde_json::Value;
 use std::sync::Arc;
@@ -197,6 +196,7 @@ struct MatchResult {
     args: Vec<String>,
     matched_sentence: String,
     processing_time: std::time::Duration,
+    match_type: String,
 }
 
 #[derive(Clone)]     
@@ -282,7 +282,7 @@ impl YoDo {
         entries.push(format!("{} ms", ms));
 
         let average = if count > 0 { sum as f64 / count as f64 } else { 0.0 };
-        let header = format!("Average: {:.2} ms ({} entries)", average, count);
+        let header = format!("{:.2} ms average ({} entries)", average, count);
         let mut output = header + "\n";
         for entry in &entries {
             output.push_str(entry);
@@ -293,7 +293,7 @@ impl YoDo {
     }
 
     fn normalize_input(input: &str) -> String {
-        input.replace(['?', '!', '.', ',', '&', '/'], "").to_lowercase()
+        input.replace(['?', '!', '.', ',', '&', '/', '\''], "").to_lowercase().split_whitespace().collect::<Vec<_>>().join(" ")
     }
 
     fn is_param_token(word: &str) -> Option<&str> {
@@ -323,9 +323,9 @@ impl YoDo {
                     0
                 } else { 1 };
 
-                dp[i][j] = (dp[i - 1][j] + 1)        // deletion
-                    .min(dp[i][j - 1] + 1)          // insertion
-                    .min(dp[i - 1][j - 1] + cost); // match/substitute
+                dp[i][j] = (dp[i - 1][j] + 1)
+                    .min(dp[i][j - 1] + 1)
+                    .min(dp[i - 1][j - 1] + cost);
             }
         }
 
@@ -462,19 +462,6 @@ impl YoDo {
         }; 
         Ok(MemoryData { context, history })
     }
-
-    async fn process_transcription(&self, text: &str) -> Result<(), Box<dyn std::error::Error>> {
-        dt_info(&format!("Real-time transcription: {}", text));
-        
-        if let Some(match_result) = self.exact_match(text) {
-            self.execute_script(&match_result)?;
-        } else if let Some(match_result) = self.fuzzy_match(text) {
-            self.execute_script(&match_result)?;
-        } else { dt_debug(&format!("No command found for: {}", text)); }
-        
-        Ok(())
-    }
-    
 
     // 🦆 says ⮞ never fail but log failz anywayz
     fn log_failed_command(&self, input: &str, fuzzy_candidates: &[(String, String, i32)]) -> Result<(), Box<dyn std::error::Error>> {
@@ -961,6 +948,7 @@ impl YoDo {
                                 args,
                                 matched_sentence: text.clone(),
                                 processing_time: global_start.elapsed(),
+                                match_type: "exact".to_string(),
                             });
                         }
                     }
@@ -1021,57 +1009,76 @@ impl YoDo {
             .max_by_key(|&(_, _, score)| score)
     }
         
+    
     fn fuzzy_match(&self, text: &str) -> Option<MatchResult> {
         dt_debug(&format!("Starting FUZZY match for: '{}'", text));
     
-        if let Some((script_name, sentence, score)) = self.find_best_fuzzy_match(text) {  
-            dt_info(&format!("Fuzzy match: {} (score: {}%)", script_name, score));
+        let (script_name, _sentence, score) = self.find_best_fuzzy_match(text)?;
+        dt_info(&format!("Fuzzy match: {} (score: {}%)", script_name, score));
     
-            let input_words: Vec<String> = text.split_whitespace().map(|s| s.to_string()).collect();
-            let sentence_words: Vec<String> = sentence.split_whitespace().map(|s| s.to_string()).collect();
+        let input_words: Vec<String> = text.split_whitespace().map(|s| s.to_string()).collect();
+        let intent = self.intent_data.get(&script_name)?;
     
-            let alignment = self.align_words(&sentence_words, &input_words);
+        for sentence in &intent.sentences {
+            for pattern_str in self.expand_optional_words(sentence) {
+                let pattern_words: Vec<String> = pattern_str
+                    .split_whitespace()
+                    .map(|s| s.to_string())
+                    .collect();
     
-            let mut args = Vec::new();
+                let alignment = self.align_words(&pattern_words, &input_words);
     
-            for (i, word) in sentence_words.iter().enumerate() {
-                if let Some(param_name) = Self::is_param_token(word) {
-                    let param_value = match alignment[i] {
-                        Some(idx) => input_words[idx].clone(),
-                        None => String::new(),
-                    };
+                let mut args = Vec::new();
+                let mut valid = true;
     
-                    let resolved_value = self.resolve_entity(&script_name, param_name, &param_value);
-
-                    if !self.is_valid_param_value(&script_name, param_name, &resolved_value) {
-                        dt_debug(&format!(
-                            "Skipping fuzzy match because param '{}' value '{}' is not allowed",
-                            param_name, resolved_value
-                        ));
-                        return None;
+                for (i, word) in pattern_words.iter().enumerate() {
+                    if let Some(param_name) = Self::is_param_token(word) {
+                        let raw_value = match alignment[i] {
+                            Some(idx) => input_words[idx].clone(),
+                            None => {
+                                valid = false;
+                                break;
+                            }
+                        };
+    
+                        let resolved = self.resolve_entity(&script_name, param_name, &raw_value);
+                        if !self.is_valid_param_value(&script_name, param_name, &resolved) {
+                            valid = false;
+                            break;
+                        }
+    
+                        args.push(format!("--{}", param_name));
+                        args.push(resolved);
                     }
-
-                    args.push(format!("--{}", param_name));
-                    args.push(resolved_value);
+                }
+    
+                if valid {
+                    return Some(MatchResult {
+                        script_name,
+                        args,
+                        matched_sentence: text.to_string(),
+                        processing_time: std::time::Duration::default(),
+                        match_type: "fuzzy".to_string(),
+                    });
                 }
             }
-    
-            Some(MatchResult {
-                script_name,
-                args,
-                matched_sentence: text.to_string(),
-                processing_time: std::time::Duration::default(),
-            })
-        } else {
-            dt_debug("No fuzzy match found");
-            None
         }
+    
+        Some(MatchResult {
+            script_name,
+            args: Vec::new(),
+            matched_sentence: text.to_string(),
+            processing_time: std::time::Duration::default(),
+            match_type: "fuzzy".to_string(),
+        })
     }
-
+    
     // 🦆 says ⮞ UPDATE CONTEXT AFTER COMMAND EXECUTION
     fn update_memory_context(&self, script_name: &str, args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         let stats_dir = std::env::var("HOME").unwrap_or_else(|_| ".".to_string()) + "/.local/share/yo/stats";
         let context_path = format!("{}/current_context.json", stats_dir);
+        std::fs::create_dir_all(&stats_dir)?;
+
         let mut context = self.memory_data.context.clone();
         // 🦆says ⮞update da last action
         context.last_action = script_name.to_string();
@@ -1117,7 +1124,7 @@ impl YoDo {
         dt_debug!("🦆MEMORY:SCRIPT:{}", result.script_name);
         dt_debug!("🦆MEMORY:ARGS:{}", result.args.join(" "));
         dt_debug!("🦆MEMORY:SENTENCE:{}", result.matched_sentence);
-        dt_debug!("🦆MEMORY:TYPE:exact");
+        dt_debug!("🦆MEMORY:TYPE:{}", result.match_type);
 
         // 🦆 says ⮞ UPDATE MEMORY CONTEXT
         if let Err(e) = self.update_memory_context(&result.script_name, &result.args) {
@@ -1126,7 +1133,10 @@ impl YoDo {
                
         // 🦆 says ⮞ execution duck tree climber
         println!("   ┌─(yo-{})", result.script_name);
-        println!("   │🦆 qwack!? {}", result.matched_sentence);       
+        let quack = if result.match_type == "exact" {
+            "quack!"
+        } else { "quack?!" };
+        println!("   │🦆 {} {}", quack, result.matched_sentence);
         if result.args.is_empty() {
             println!("   └─🦆 says ⮞ no parameters yo");
         } else {
@@ -1278,6 +1288,7 @@ impl YoDo {
                 args: match_result.args,
                 matched_sentence: match_result.matched_sentence,
                 processing_time: part_elapsed,
+                match_type: "exact".to_string(),
             };
             self.execute_script(&final_result)?;
             return Ok(());
@@ -1292,6 +1303,7 @@ impl YoDo {
                 args: match_result.args,
                 matched_sentence: match_result.matched_sentence,
                 processing_time: part_elapsed,
+                match_type: "fuzzy".to_string(),
             };
             let _ = self.log_successful_command(&final_result.script_name, &final_result.args, final_result.processing_time);
             self.execute_script(&final_result)?;
@@ -1326,19 +1338,19 @@ impl YoDo {
 fn load_split_words() -> Vec<String> {
     let path = std::env::var("YO_SPLIT_WORDS")
         .unwrap_or_else(|_| DEFAULT_SPLIT_WORDS_PATH.to_string());
-    let content = fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("Failed to read split words file from {}: {}", path, e));
-    serde_json::from_str(&content)
-        .unwrap_or_else(|e| panic!("Invalid JSON in split words file {}: {}", path, e))
+    match fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Err(_) => Vec::new(),
+    }
 }
 
 fn load_sorry_phrases() -> Vec<String> {
     let path = std::env::var("YO_SORRY_PHRASES")
         .unwrap_or_else(|_| DEFAULT_SORRY_PHRASES_PATH.to_string());
-    let content = fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("Failed to read sorry phrases file from {}: {}", path, e));
-    serde_json::from_str(&content)
-        .unwrap_or_else(|e| panic!("Invalid JSON in sorry phrases file {}: {}", path, e))
+    match fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Err(_) => Vec::new(),
+    }
 }
 
 
@@ -1419,4 +1431,368 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     yo_do.run(&input, cli.fuzzy)
+}
+
+
+
+
+// TESTS
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    const TEST_INTENT_JSON: &str = r#"
+    {
+      "timer": {
+        "sentences": [
+          "set a timer for {minutes} minutes and {seconds} seconds",
+          "start timer {minutes} minutes"
+        ],
+        "lists": {
+          "minutes": { "wildcard": false, "values": [ {"in": "5", "out": "5"}, {"in": "10", "out": "10"} ] },
+          "seconds": { "wildcard": false, "values": [ {"in": "30", "out": "30"}, {"in": "45", "out": "45"} ] }
+        },
+        "substitutions": []
+      },
+      "reminder": {
+        "sentences": [
+          "set a reminder for {time} to {task}"
+        ],
+        "lists": {
+          "time": { "wildcard": false, "values": [ {"in": "8am", "out": "08:00"} ] },
+          "task": { "wildcard": true, "values": [] }
+        },
+        "substitutions": []
+      },
+      "play": {
+        "sentences": [
+          "play [some] music by {artist}",
+          "play {song} by {artist}"
+        ],
+        "lists": {
+          "artist": { "wildcard": false, "values": [] },
+          "song": { "wildcard": true, "values": [] }
+        },
+        "substitutions": [
+          { "pattern": "beatles", "value": "beatles_band" },
+          { "pattern": "queen", "value": "queen" }
+        ]
+      }
+    }
+    "#;
+
+    const TEST_FUZZY_INDEX_JSON: &str = r#"
+    [
+      {
+        "script": "timer",
+        "sentence": "set a timer for 5 minutes and 30 seconds",
+        "signature": "timer_5_30",
+        "fuzzy_threshold": 0.8,
+        "fuzzy_enabled": true
+      },
+      {
+        "script": "reminder",
+        "sentence": "set a reminder for 8am to buy milk",
+        "signature": "reminder_8am_buy milk",
+        "fuzzy_threshold": 0.8,
+        "fuzzy_enabled": true
+      },
+      {
+        "script": "play",
+        "sentence": "play some music by the beatles",
+        "signature": "play_beatles",
+        "fuzzy_threshold": 0.75,
+        "fuzzy_enabled": true
+      }
+    ]
+    "#;
+
+    fn create_test_yodo() -> YoDo {
+        let mut yodo = YoDo::new();
+        yodo.intent_data = serde_json::from_str(TEST_INTENT_JSON).unwrap();
+        yodo.fuzzy_index = serde_json::from_str(TEST_FUZZY_INDEX_JSON).unwrap();
+        yodo.precompile_patterns();
+        yodo.calculate_processing_order();
+        yodo
+    }
+
+    struct TempHomeGuard {
+        original_home: Option<String>,
+        temp_dir: std::path::PathBuf,
+    }
+
+    impl TempHomeGuard {
+        fn new() -> Self {
+            let original_home = std::env::var("HOME").ok();
+            let temp_dir = std::env::temp_dir().join(format!(
+                "yo_do_test_{}_{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            ));
+            std::fs::create_dir_all(&temp_dir).unwrap();
+            std::env::set_var("HOME", &temp_dir);
+            Self {
+                original_home,
+                temp_dir,
+            }
+        }
+    }
+
+    impl Drop for TempHomeGuard {
+        fn drop(&mut self) {
+            if let Some(orig) = &self.original_home {
+                std::env::set_var("HOME", orig);
+            } else {
+                std::env::remove_var("HOME");
+            }
+            let _ = std::fs::remove_dir_all(&self.temp_dir);
+        }
+    }
+
+    #[test]
+    fn test_levenshtein_distance() {
+        let yodo = YoDo::new();
+        assert_eq!(yodo.levenshtein_distance("kitten", "sitting"), 3);
+        assert_eq!(yodo.levenshtein_distance("", "abc"), 3);
+        assert_eq!(yodo.levenshtein_distance("abc", "abc"), 0);
+        assert_eq!(yodo.levenshtein_distance("flaw", "lawn"), 2);
+    }
+
+    #[test]
+    fn test_normalize_input() {
+        assert_eq!(YoDo::normalize_input("Hello, World!"), "hello world");
+        assert_eq!(YoDo::normalize_input("What's up?"), "whats up");
+        assert_eq!(YoDo::normalize_input("  Multiple   Spaces  "), "multiple spaces");
+        assert_eq!(YoDo::normalize_input("UPPER lower MiXeD"), "upper lower mixed");
+        assert_eq!(YoDo::normalize_input("Punctuation! & symbols/"), "punctuation symbols");
+    }
+
+    #[test]
+    fn test_expand_optional_words() {
+        let yodo = YoDo::new();
+        let variants = yodo.expand_optional_words("turn [on|off] the light");
+        assert!(variants.contains(&"turn on the light".to_string()));
+        assert!(variants.contains(&"turn off the light".to_string()));
+        assert!(variants.contains(&"turn the light".to_string()));
+        let variants2 = yodo.expand_optional_words("play [some] music");
+        assert!(variants2.contains(&"play some music".to_string()));
+        assert!(variants2.contains(&"play music".to_string()));
+        let variants3 = yodo.expand_optional_words("set (high|low) volume");
+        assert!(variants3.contains(&"set high volume".to_string()));
+        assert!(variants3.contains(&"set low volume".to_string()));
+        assert!(!variants3.contains(&"set volume".to_string()));
+    }
+
+    #[test]
+    fn test_build_pattern_matcher_simple() {
+        let yodo = create_test_yodo();
+        let (regex, params) = yodo.build_pattern_matcher("timer", "set a timer for {minutes} minutes").unwrap();
+        assert_eq!(params, vec!["minutes".to_string()]);
+        assert!(regex.is_match("set a timer for 5 minutes"));
+        assert!(!regex.is_match("set a timer for minutes"));
+    }
+
+    #[test]
+    fn test_build_pattern_matcher_wildcard() {
+        let yodo = create_test_yodo();
+        let (regex, params) = yodo.build_pattern_matcher("reminder", "set a reminder for {time} to {task}").unwrap();
+        assert_eq!(params, vec!["time".to_string(), "task".to_string()]);
+        assert!(regex.is_match("set a reminder for 8am to buy milk"));
+        assert!(regex.is_match("set a reminder for 8am to anything with spaces"));
+        assert!(!regex.is_match("set a reminder for to buy milk"));
+    }
+
+    #[test]
+    fn test_align_words_exact() {
+        let yodo = YoDo::new();
+        let pattern = vec!["set".to_string(), "{param}".to_string(), "timer".to_string()];
+        let text = vec!["set".to_string(), "a".to_string(), "timer".to_string()];
+        let alignment = yodo.align_words(&pattern, &text);
+        assert_eq!(alignment, vec![Some(0), Some(1), Some(2)]);
+    }
+
+    #[test]
+    fn test_align_words_with_extra_words() {
+        let yodo = YoDo::new();
+        let pattern = vec!["play".to_string(), "{song}".to_string()];
+        let text = vec!["play".to_string(), "the".to_string(), "beatles".to_string()];
+        let alignment = yodo.align_words(&pattern, &text);
+        assert!(alignment[1].is_some());
+    }
+
+    #[test]
+    fn test_exact_match_timer() {
+        let yodo = create_test_yodo();
+        let result = yodo.exact_match("set a timer for 10 minutes and 45 seconds").unwrap();
+        assert_eq!(result.script_name, "timer");
+        assert_eq!(result.args, vec!["--minutes", "10", "--seconds", "45"]);
+        assert_eq!(result.match_type, "exact");
+    }
+
+    #[test]
+    fn test_exact_match_reminder_wildcard() {
+        let yodo = create_test_yodo();
+        let result = yodo.exact_match("set a reminder for 8am to buy milk and eggs").unwrap();
+        assert_eq!(result.script_name, "reminder");
+        assert_eq!(result.args, vec!["--time", "08:00", "--task", "buy milk and eggs"]);
+    }
+
+    #[test]
+    fn test_exact_match_with_substitution() {
+        let yodo = create_test_yodo();
+        let result = yodo.exact_match("play some music by beatles").unwrap();
+        assert_eq!(result.script_name, "play");
+        assert!(result.args.contains(&"--artist".to_string()));
+        assert!(result.args.contains(&"beatles_band".to_string()));
+    }
+
+    #[test]
+    fn test_exact_match_optional_variant() {
+        let yodo = create_test_yodo();
+        let result = yodo.exact_match("play music by queen").unwrap();
+        assert_eq!(result.script_name, "play");
+        assert_eq!(result.args, vec!["--artist", "queen"]);
+    }
+
+    #[test]
+    fn test_exact_match_no_match() {
+        let yodo = create_test_yodo();
+        assert!(yodo.exact_match("this does not match anything").is_none());
+    }
+
+    #[test]
+    fn test_fuzzy_match_typo() {
+        let yodo = create_test_yodo();
+        let result = yodo.fuzzy_match("set a timr for 5 minuts and 30 secnds").unwrap();
+        assert_eq!(result.script_name, "timer");
+        assert!(result.args.contains(&"--minutes".to_string()));
+        assert!(result.args.contains(&"--seconds".to_string()));
+    }
+
+    #[test]
+    fn test_fuzzy_match_distinguishes_timer_reminder() {
+        let yodo = create_test_yodo();
+        let result = yodo.fuzzy_match("set a remindr for 8am to buy milk").unwrap();
+        assert_eq!(result.script_name, "reminder");
+    }
+
+    #[test]
+    fn test_fuzzy_match_threshold() {
+        let mut yodo = create_test_yodo();
+        yodo.fuzzy_index[0].fuzzy_threshold = 0.99;
+        assert!(yodo.fuzzy_match("completely unrelated sentence").is_none());
+    }
+
+    #[test]
+    fn test_find_best_fuzzy_match() {
+        let yodo = create_test_yodo();
+        let best = yodo.find_best_fuzzy_match("set a timr for 5 minuts and 30 secnds");
+        assert!(best.is_some());
+        let (script, _sentence, score) = best.unwrap();
+        assert_eq!(script, "timer");
+        assert!(score >= 70);
+    }
+
+    #[test]
+    fn test_resolve_entity_list_exact() {
+        let yodo = create_test_yodo();
+        assert_eq!(yodo.resolve_entity("timer", "minutes", "5"), "5");
+        assert_eq!(yodo.resolve_entity("timer", "minutes", "10"), "10");
+        assert_eq!(yodo.resolve_entity("timer", "minutes", "15"), "15");
+    }
+
+    #[test]
+    fn test_resolve_entity_wildcard() {
+        let yodo = create_test_yodo();
+        assert_eq!(yodo.resolve_entity("reminder", "task", "buy milk"), "buy milk");
+    }
+
+    #[test]
+    fn test_resolve_entity_substitution() {
+        let yodo = create_test_yodo();
+        assert_eq!(yodo.resolve_entity("play", "artist", "beatles"), "beatles_band");
+        assert_eq!(yodo.resolve_entity("play", "artist", "queen"), "queen");
+    }
+
+    #[test]
+    fn test_is_wildcard_param() {
+        let yodo = create_test_yodo();
+        assert!(!yodo.is_wildcard_param("timer", "minutes"));
+        assert!(yodo.is_wildcard_param("reminder", "task"));
+        assert!(!yodo.is_wildcard_param("play", "artist"));
+        assert!(yodo.is_wildcard_param("play", "song"));
+    }
+
+    #[test]
+    fn test_is_valid_param_value() {
+        let yodo = create_test_yodo();
+        assert!(yodo.is_valid_param_value("timer", "minutes", "5"));
+        assert!(yodo.is_valid_param_value("timer", "minutes", "10"));
+        assert!(!yodo.is_valid_param_value("timer", "minutes", "15"));
+        assert!(yodo.is_valid_param_value("reminder", "task", "anything"));
+        assert!(yodo.is_valid_param_value("play", "artist", "the beatles"));
+    }
+
+    #[test]
+    fn test_fuzzy_resolve_entity() {
+        let mut yodo = create_test_yodo();
+        let mut param_dict = HashMap::new();
+        param_dict.insert(
+            "artist".to_string(),
+            vec![
+                EntityMapping { input: "the beatles".to_string(), output: "the beatles".to_string() },
+                EntityMapping { input: "beetles".to_string(), output: "the beatles".to_string() },
+            ],
+        );
+        yodo.fuzzy_entity_dict.insert("play".to_string(), param_dict);
+        assert_eq!(yodo.fuzzy_resolve_entity("play", "artist", "beetles", 80), Some("the beatles".to_string()));
+        assert_eq!(yodo.fuzzy_resolve_entity("play", "artist", "rolling stones", 80), None);
+    }
+
+    #[test]
+    fn test_apply_real_time_substitutions() {
+        let yodo = create_test_yodo();
+        let (resolved, subs) = yodo.apply_real_time_substitutions("play", "play music by beatles");
+        assert_eq!(resolved, "play music by beatles_band");
+        assert_eq!(subs.get("beatles"), Some(&"beatles_band".to_string()));
+    }
+
+    #[test]
+    fn test_update_memory_context() {
+        let _guard = TempHomeGuard::new();
+        let yodo = create_test_yodo();
+        let script = "timer";
+        let args = vec!["--minutes".to_string(), "5".to_string()];
+        let result = yodo.update_memory_context(script, &args);
+        assert!(result.is_ok());
+        let memory = YoDo::load_memory_data().unwrap();
+        assert_eq!(memory.context.last_action, script);
+    }
+
+    #[test]
+    fn test_empty_input_exact_match() {
+        let yodo = create_test_yodo();
+        assert!(yodo.exact_match("").is_none());
+    }
+
+    #[test]
+    fn test_empty_input_fuzzy_match() {
+        let yodo = create_test_yodo();
+        assert!(yodo.fuzzy_match("").is_none());
+    }
+
+    #[test]
+    fn test_no_patterns_compiled() {
+        let mut yodo = YoDo::new();
+        yodo.intent_data = serde_json::from_str("{}").unwrap();
+        yodo.precompile_patterns();
+        yodo.calculate_processing_order();
+        assert!(yodo.exact_match("anything").is_none());
+        assert!(yodo.fuzzy_match("anything").is_none());
+    }
 }

--- a/packages/yo-rs/src/yo-say.rs
+++ b/packages/yo-rs/src/yo-say.rs
@@ -141,30 +141,37 @@ fn convert_and_replace(path: &str) -> io::Result<()> {
     Ok(())
 }
 
-fn get_esp_ips() -> Vec<String> {
+fn read_clients() -> Option<Vec<serde_json::Value>> {
     let home = std::env::var("HOME").unwrap_or_else(|_| {
         dt_warning!("HOME environment variable not set, using empty");
         String::new()
     });
-    let path = format!("{}/.config/yo/clients.json", home);
 
-    let data = match std::fs::read_to_string(&path) {
-        Ok(d) => {
-            dt_debug!("Read clients.json from {}", path);
-            d
-        }
-        Err(e) => {
-            dt_warning!("Could not read {}: {}", path, e);
-            return vec![];
-        }
-    };
+    let paths = vec![
+        format!("{}/.config/yo/clients.json", home),
+        "/etc/yo/clients.json".to_string(),
+    ];
 
-    let clients: Vec<serde_json::Value> = match serde_json::from_str(&data) {
-        Ok(c) => c,
-        Err(e) => {
-            dt_warning!("Could not parse {} as JSON: {}", path, e);
-            return vec![];
+    for path in paths {
+        match std::fs::read_to_string(&path) {
+            Ok(data) => {
+                dt_debug!("Read clients.json from {}", path);
+                match serde_json::from_str(&data) {
+                    Ok(clients) => return Some(clients),
+                    Err(e) => { dt_warning!("Could not parse {} as JSON: {}", path, e); }
+                }
+            }
+            Err(e) => { dt_warning!("Could not read {}: {}", path, e); }
         }
+    }
+    dt_warning!("No valid clients.json found in any standard location");
+    None
+}
+
+fn get_esp_ips() -> Vec<String> {
+    let clients = match read_clients() {
+        Some(c) => c,
+        None => return vec![],
     };
 
     let ips: Vec<String> = clients
@@ -174,35 +181,15 @@ fn get_esp_ips() -> Vec<String> {
         .collect();
 
     if ips.is_empty() {
-        dt_debug!("No ESP devices found in {}", path);
+        dt_debug!("No ESP devices found in clients.json");
     } else { dt_info!("Found {} ESP device(s): {:?}", ips.len(), ips); }
     ips
 }
 
 fn get_client_ips() -> Vec<String> {
-    let home = std::env::var("HOME").unwrap_or_else(|_| {
-        dt_warning!("HOME environment variable not set, using empty");
-        String::new()
-    });
-    let path = format!("{}/.config/yo/clients.json", home);
-
-    let data = match std::fs::read_to_string(&path) {
-        Ok(d) => {
-            dt_debug!("Read clients.json from {}", path);
-            d
-        }
-        Err(e) => {
-            dt_warning!("could not read {}: {}", path, e);
-            return vec![];
-        }
-    };
-
-    let clients: Vec<serde_json::Value> = match serde_json::from_str(&data) {
-        Ok(c) => c,
-        Err(e) => {
-            dt_warning!("could not parse {} as JSON: {}", path, e);
-            return vec![];
-        }
+    let clients = match read_clients() {
+        Some(c) => c,
+        None => return vec![],
     };
 
     let ips: Vec<String> = clients
@@ -215,7 +202,7 @@ fn get_client_ips() -> Vec<String> {
         .collect();
 
     if ips.is_empty() {
-        dt_debug!("No non‑ESP clients found in {}", path);
+        dt_debug!("No non‑ESP clients found in clients.json");
     } else { dt_info!("Found {} client device(s): {:?}", ips.len(), ips); }
     ips
 }

--- a/services.nix
+++ b/services.nix
@@ -339,6 +339,12 @@ in {
         description = "Maximum recording length (fallback).";
       };
 
+      ttsClients = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "optional list of hardcoded client IP addresses for text-to-spech streams.";
+      };      
+
       extraArgs = mkOption {
         type = types.listOf types.str;
         default = [ ];
@@ -459,8 +465,8 @@ in {
               ++ [ "--silence-threshold" (toString cfg.client.silenceThreshold) ]
               ++ [ "--silence-timeout" (toString cfg.client.silenceTimeout) ]
               ++ [ "--max-duration" (toString cfg.client.maxDuration) ]
-              ++ (if (cfg.client.room != null) then [ "--room" cfg.client.room ]
-                  else if (cfg.server.enable && cfg.client.enable) then [ "--room" "local" ]
+              ++ (if (cfg.server.enable && cfg.client.enable) then [ "--room" "local" ]
+                  else if (cfg.client.room != null) then [ "--room" cfg.client.room ]
                   else [])
               ++ optionals cfg.client.debug [ "--debug" ]
               ++ optionals ((cfg.server.enable && cfg.client.enable)) [ "--no-bind" ]
@@ -469,6 +475,17 @@ in {
           };
         };
       };
+      
+      environment.etc."yo/clients.json" = {
+        text = builtins.toJSON (
+          map (ip: {
+            room = "client";
+            ip = ip;
+            connected_at = 0;
+          }) cfg.client.ttsClients
+        );
+      };
+      
     })
        
   ];}


### PR DESCRIPTION
## Summary
- Upgraded `whisper-rs` from 0.8 to 0.16, adapting API calls and adding transcription benchmark logging.
- Added `match_type` field to differentiate exact/fuzzy matches, improved fuzzy matching validation across patterns, and introduced unit tests.
- Updated Nix module and services: disabled fuzzy CLI flag, added `ttsClients` option, number formatting, and help output changes.
- Updated documentation, CI workflow, and README.

## Why
- Upgrade `whisper-rs` for better performance, bug fixes, and API improvements.
- Improve matching reliability by validating all fuzzy patterns and providing clearer feedback (exact vs fuzzy quack).
- Enhance test coverage for core matching and normalization logic.
- Add configuration flexibility (hardcoded TTS clients) and improve output formatting.

## Notes
- The `fuzzy` command parameter is temporarily commented out in `module.nix`; it may be re-enabled later.
- Whisper API changes require careful review; transcription benchmark logging is new.
- `ttsClients` generates `/etc/yo/clients.json` for static client IPs.